### PR TITLE
ui: 그룹 상세 액티비티 및 관리 UI 추가 (#39)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,14 @@
             android:exported="false">
         </activity>
 
+        <activity
+            android:name=".group.GroupGenerationActivity"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"/>
+
+        <activity
+            android:name=".group.GroupJoinManagementActivity"
+            android:exported="false"/>
 
         <activity
             android:name=".trk.HostActivity"

--- a/app/src/main/java/com/bookiibookii/bookiibookii/common/CommonDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/common/CommonDialog.kt
@@ -1,0 +1,76 @@
+package com.bookiibookii.bookiibookii.common
+
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.Window
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
+import com.bookiibookii.bookiibookii.databinding.DialogCommonBinding
+
+class CommonDialog(
+    context: Context,
+    private val title: String,
+    private val subtitle: String,
+    private val content: String,
+    private val confirmBtnText: String,
+    @ColorRes private val confirmBtnColor: Int, // 색상 리소스 ID (R.color.xxx)
+    private val onConfirmClick: () -> Unit,     // 확인 버튼 람다
+    private val onCancelClick: (() -> Unit)? = null // 취소 버튼 람다 (선택)
+) : Dialog(context) {
+
+    private lateinit var binding: DialogCommonBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // 윈도우 배경 투명 처리
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        binding = DialogCommonBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        initView()
+        initListener()
+    }
+
+    private fun initView() {
+        with(binding) {
+            // 텍스트 세팅
+            dialogTitleTv.text = title
+            dialogSubtitleTv.text = subtitle
+            dialogContentTv.text = content
+            dialogConfirmBtn.text = confirmBtnText
+
+            // 버튼 색상 변경
+            dialogConfirmBtn.backgroundTintList =
+                ContextCompat.getColorStateList(context, confirmBtnColor)
+        }
+    }
+
+    private fun initListener() {
+        with(binding) {
+            // 닫기 (X) 아이콘
+            dialogCloseIv.setOnClickListener {
+                dismiss()
+                onCancelClick?.invoke()
+            }
+
+            // 취소 버튼
+            dialogCancelBtn.setOnClickListener {
+                dismiss()
+                onCancelClick?.invoke()
+            }
+
+            // 확인 버튼
+            dialogConfirmBtn.setOnClickListener {
+                dismiss()
+                onConfirmClick()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupDetailActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupDetailActivity.kt
@@ -1,6 +1,7 @@
 package com.bookiibookii.bookiibookii.group
 
 import android.app.Dialog
+import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -12,8 +13,9 @@ import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.common.CommonDialog
 import com.bookiibookii.bookiibookii.databinding.ActivityGrpHostBinding
-import com.bookiibookii.bookiibookii.databinding.DialogGroupDeleteBinding
 import com.bookiibookii.bookiibookii.databinding.DialogGroupJoinBinding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 
@@ -22,10 +24,10 @@ class GroupDetailActivity : AppCompatActivity() {
     private lateinit var binding: ActivityGrpHostBinding
     private lateinit var bottomSheetBehavior: BottomSheetBehavior<View>
 
-    // 호스트 여부를 저장할 변수 (기본값: 게스트)
+    // 호스트 여부를 저장할 변수
     private var isHost: Boolean = false
 
-    // (예시) 현재 접속자 ID와 방장 ID
+    // 현재 접속자 ID와 방장 ID
     private val currentUserId = "user123"
     private val groupHostId = "user123" // 나중엔 DB에서 받아온 값
 
@@ -53,7 +55,9 @@ class GroupDetailActivity : AppCompatActivity() {
 
             // 버튼 클릭 시 관리 페이지로 이동
             itemBinding.grpItemMgManageBtn.setOnClickListener {
-                // 관리 페이지 이동 로직//
+                val intent = Intent(this, GroupJoinManagementActivity::class.java)
+
+                startActivity(intent)
             }
 
         } else {
@@ -93,7 +97,6 @@ class GroupDetailActivity : AppCompatActivity() {
 
     }
     private fun checkUserAuthority() {
-        // 실제로는 API 통신 후 비교하겠지만, 로직은 이렇습니다.
         isHost = (currentUserId == groupHostId)
 
         if (isHost) {
@@ -210,28 +213,18 @@ class GroupDetailActivity : AppCompatActivity() {
     }
 
     private fun showDeleteDialog() {
-        val dialog = Dialog(this)
-        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
-
-        val dialogBinding = DialogGroupDeleteBinding.inflate(layoutInflater)
-        dialog.setContentView(dialogBinding.root)
-
-        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
-        dialog.window?.setLayout(
-            WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.WRAP_CONTENT
+        val dialog = CommonDialog(
+            context = this,
+            title = "그룹 삭제",
+            subtitle = "괴테는 모든 것을 말했다",
+            content = "그룹을 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+            confirmBtnText = "삭제",
+            confirmBtnColor = R.color.ui_point_red,
+            onConfirmClick = {
+                // 삭제 API 호출 로직
+                Toast.makeText(this, "그룹이 삭제되었습니다.", Toast.LENGTH_SHORT).show()
+            }
         )
-        dialogBinding.dialogDeleteCancelBtn.setOnClickListener {
-            dialog.dismiss()
-        }
-
-        dialogBinding.dialogDeleteEnterBtn.setOnClickListener {
-            // TODO: 실제 서버에 삭제 요청 보내기
-            Toast.makeText(this, "그룹이 삭제되었습니다.", Toast.LENGTH_SHORT).show()
-            dialog.dismiss()
-            finish()
-        }
-
         dialog.show()
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupFragment.kt
@@ -141,6 +141,11 @@ class GroupFragment : Fragment() {
             }
             bottomSheet.show(parentFragmentManager, "FilterBottomSheet")
         }
+
+        binding.grpGroupListIv.setOnClickListener {
+            val intent = Intent(requireContext(), GroupGenerationActivity::class.java)
+            startActivity(intent)
+        }
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupGenerationActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupGenerationActivity.kt
@@ -1,0 +1,177 @@
+package com.bookiibookii.bookiibookii.group
+
+import android.app.Dialog
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.Window
+import android.view.WindowManager
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.common.CommonDialog
+import com.bookiibookii.bookiibookii.databinding.ActivityGrpGenerationBinding
+import com.google.android.material.datepicker.MaterialDatePicker
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class GroupGenerationActivity : AppCompatActivity() {
+
+    // 뷰 바인딩 선언
+    private lateinit var binding: ActivityGrpGenerationBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // 바인딩 초기화 및 뷰 설정
+        binding = ActivityGrpGenerationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        initListener()
+    }
+
+    private fun initListener() {
+        with(binding) {
+            // 뒤로가기 버튼
+            actGrpGenBackIv.setOnClickListener {
+                finish()
+            }
+
+            // 시작 날짜 선택 (MaterialDatePicker)
+            actGrpGenBookDateContainer.setOnClickListener {
+                val datePicker = MaterialDatePicker.Builder.datePicker()
+                    .setTitleText("시작 날짜 선택")
+                    .setSelection(MaterialDatePicker.todayInUtcMilliseconds())
+                    .build()
+
+                datePicker.addOnPositiveButtonClickListener { selection ->
+                    val sdf = SimpleDateFormat("yyyy.MM.dd", Locale.KOREA)
+                    val dateString = sdf.format(Date(selection))
+
+                    // 선택된 날짜 텍스트뷰에 반영
+                    actGrpGenBookSelectDateTv.text = dateString
+                    // 텍스트 색상을 검은색으로 변경 (혹시 초기값이 회색이었다면)
+                    actGrpGenBookSelectDateTv.setTextColor(getColor(R.color.grey_900))
+                }
+                datePicker.show(supportFragmentManager, "DATE_PICKER")
+            }
+
+            // 실물 책 소지 여부 (네/아니오 버튼 토글)
+            actGrpGenBookYesBtn.setOnClickListener {
+                updateBookHaveState(true)
+            }
+
+            actGrpGenBookNoBtn.setOnClickListener {
+                updateBookHaveState(false)
+                showBuyDialog()
+            }
+
+            //  그룹 만들기 완료 버튼
+            actGrpGenRunBtn.setOnClickListener {
+                // TODO: 입력된 데이터 수집 및 서버 전송 로직
+            }
+        }
+    }
+    // 도서 구매 다이얼로그 띄우기
+//    private fun showBuyDialog() {
+//        val dialog = Dialog(this)
+//        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+//
+//        val dialogBinding = DialogGroupBuyBinding.inflate(layoutInflater)
+//        dialog.setContentView(dialogBinding.root)
+//
+//        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+//        dialog.window?.setLayout(
+//            WindowManager.LayoutParams.WRAP_CONTENT,
+//            WindowManager.LayoutParams.WRAP_CONTENT
+//        )
+//
+//        // [취소 버튼] -> 다이얼로그 닫고, 버튼 선택 상태 초기화
+//        dialogBinding.dialogBuyCancelBtn.setOnClickListener {
+//            dialog.dismiss()
+//            updateBookHaveState(null) // 여기서 버튼 상태를 Reset
+//        }
+//
+//        // [닫기 아이콘] -> 취소와 동일하게 처리
+//        dialogBinding.dialogBuyCloseIv.setOnClickListener {
+//            dialog.dismiss()
+//            updateBookHaveState(null)
+//        }
+//
+//        // [구매하러 가기 버튼] -> 토스트 메시지 후 다이얼로그 닫기
+//        dialogBinding.dialogBuyEnterBtn.setOnClickListener {
+//            Toast.makeText(this, "구매 사이트로 이동합니다 (추후 구현)", Toast.LENGTH_SHORT).show()
+//            dialog.dismiss()
+//            updateBookHaveState(null)
+//        }
+//
+//        dialog.show()
+//    }
+    private fun showBuyDialog() {
+        val dialog = CommonDialog(
+            context = this,
+            title = "책을 먼저 구매하시겠습니까?",
+            subtitle = "괴테는 모든 것을 말했다",
+            content = "그룹을 만들기 위해서는 실물 책이 필요합니다.구매페이지로 이동할까요?",
+            confirmBtnText = "구매하러 가기",
+            confirmBtnColor = R.color.grey_900,
+            onConfirmClick = {
+                // 구매 페이지 이동 로직
+                Toast.makeText(this, "구매 페이지로 이동합니다.", Toast.LENGTH_SHORT).show()
+                updateBookHaveState(null)
+
+            },
+            onCancelClick = {
+                // 취소 시 (Reset) 로직
+                updateBookHaveState(null)
+            }
+        )
+        dialog.show()
+    }
+
+    private fun updateBookHaveState(isHave: Boolean?) {
+        val mainColor = ContextCompat.getColorStateList(this, R.color.pre_main)
+        val paleColor = ContextCompat.getColorStateList(this, R.color.pre_main_pale)
+        val grey200 = ContextCompat.getColorStateList(this, R.color.grey_200)
+        val white = ContextCompat.getColorStateList(this, R.color.white)
+
+        val mainColorInt = ContextCompat.getColor(this, R.color.pre_main)
+        val grey900Int = ContextCompat.getColor(this, R.color.grey_900)
+
+        with(binding) {
+            when (isHave) {
+                true -> { // [네] 선택 시
+                    actGrpGenBookYesBtn.strokeColor = mainColor
+                    actGrpGenBookYesBtn.backgroundTintList = paleColor
+                    actGrpGenBookYesBtn.setTextColor(mainColorInt)
+
+                    actGrpGenBookNoBtn.strokeColor = grey200
+                    actGrpGenBookNoBtn.backgroundTintList = white
+                    actGrpGenBookNoBtn.setTextColor(grey900Int)
+                }
+
+                false -> { // [아니오] 선택 시
+                    actGrpGenBookNoBtn.strokeColor = mainColor
+                    actGrpGenBookNoBtn.backgroundTintList = paleColor
+                    actGrpGenBookNoBtn.setTextColor(mainColorInt)
+
+                    actGrpGenBookYesBtn.strokeColor = grey200
+                    actGrpGenBookYesBtn.backgroundTintList = white
+                    actGrpGenBookYesBtn.setTextColor(grey900Int)
+                }
+
+                null -> { // 취소 시 둘 다 비활성화
+                    actGrpGenBookYesBtn.strokeColor = grey200
+                    actGrpGenBookYesBtn.backgroundTintList = white
+                    actGrpGenBookYesBtn.setTextColor(grey900Int)
+
+                    actGrpGenBookNoBtn.strokeColor = grey200
+                    actGrpGenBookNoBtn.backgroundTintList = white
+                    actGrpGenBookNoBtn.setTextColor(grey900Int)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinAdapter.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinAdapter.kt
@@ -1,0 +1,91 @@
+package com.bookiibookii.bookiibookii.group
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bookiibookii.bookiibookii.databinding.ItemGroupJoinManagementBinding
+import com.bookiibookii.bookiibookii.R
+
+class GroupJoinAdapter(
+    private var dataList: MutableList<GroupJoinData>,
+    private val onItemClick: (GroupJoinData, Boolean) -> Unit
+) : RecyclerView.Adapter<GroupJoinAdapter.Holder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
+        val binding = ItemGroupJoinManagementBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return Holder(binding)
+    }
+
+    override fun onBindViewHolder(holder: Holder, position: Int) {
+        holder.bind(dataList[position])
+    }
+
+    override fun getItemCount(): Int = dataList.size
+
+    inner class Holder(private val binding: ItemGroupJoinManagementBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: GroupJoinData) {
+            with(binding) {
+                //기본 텍스트 및 이미지 설정
+                itemGrpJoinManageNicknameTv.text = item.nickname
+                itemGrpJoinManageDateTv.text = item.date
+                itemGrpJoinManageContentTv.text = item.intro
+
+                // 프로필 이미지
+                if (item.profileResId != null) {
+                    itemGrpJoinManageProfileIv.setImageResource(item.profileResId)
+                } else {
+                    itemGrpJoinManageProfileIv.setImageResource(R.drawable.ic_profile)
+                }
+
+                // 칩 처리 로직
+                val chipViews = listOf(
+                    grpItemJoinMgHash1Cp,
+                    grpItemJoinMgHash2Cp,
+                    grpItemJoinMgHash3Cp,
+                    grpItemJoinMgHash4Cp,
+                    grpItemJoinMgHash5Cp
+                )
+
+                chipViews.forEachIndexed { index, chipView ->
+                    if (index < item.tags.size) {
+                        // 데이터가 있는 경우 -> 텍스트 설정하고 보이게 함
+                        chipView.text = item.tags[index]
+                        chipView.visibility = View.VISIBLE
+                    } else {
+                        // 데이터가 없는 슬롯: 숨김
+                        chipView.visibility = View.GONE
+                    }
+                }
+
+                // 버튼 클릭 리스너
+                itemGrpJoinManageYesBtn.setOnClickListener {
+                    onItemClick(item, true)
+                }
+
+                itemGrpJoinManageNoBtn.setOnClickListener {
+                    onItemClick(item, false)
+                }
+            }
+        }
+    }
+
+    fun updateData(newItemList: List<GroupJoinData>) {
+        dataList.clear()
+        dataList.addAll(newItemList)
+        notifyDataSetChanged()
+    }
+
+    fun removeItem(item: GroupJoinData) {
+        val position = dataList.indexOf(item)
+        if (position != -1) {
+            dataList.removeAt(position)
+            notifyItemRemoved(position)
+            notifyItemRangeChanged(position, dataList.size)
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinData.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinData.kt
@@ -1,0 +1,9 @@
+package com.bookiibookii.bookiibookii.group
+data class GroupJoinData(
+val id: Int,                 // 유저 고유 ID
+val profileResId: Int?,      // 프로필 이미지 리소스 (URL이라면 String으로 변경)
+val nickname: String,        // 닉네임
+val date: String,            // 날짜 (ex: "2026.01.29")
+val intro: String,           // 간단 소개
+val tags: List<String>       // 태그 리스트 (ex: ["#열정", "#성실"])
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinManagemnetActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinManagemnetActivity.kt
@@ -1,0 +1,112 @@
+package com.bookiibookii.bookiibookii.group
+
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.common.CommonDialog
+import com.bookiibookii.bookiibookii.databinding.ActivityGrpJoinManagementBinding
+
+class GroupJoinManagementActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityGrpJoinManagementBinding
+    private lateinit var groupJoinAdapter: GroupJoinAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityGrpJoinManagementBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        initView()
+        initListener()
+    }
+
+    private fun initView() {
+        //더미
+        val mockData = mutableListOf(
+            GroupJoinData(1, null, "독서광", "2025.12.05", "저 진짜 열심히 할게요!",
+                listOf("#메모환영", "#인사이트", "#열정")),
+
+            GroupJoinData(2, null, "심심이", "2025.12.06", "안녕하세요",
+                listOf("#하나")),
+
+            GroupJoinData(3, null, "투머치토커", "2025.12.07", "태그 부자입니다.",
+                listOf("#일", "#이", "#삼", "#사", "#오", "#육"))
+
+        )
+
+        groupJoinAdapter = GroupJoinAdapter(mockData) { item, isAccept ->
+            if (isAccept) {
+                // 수락 버튼 클릭 시 -> 수락 다이얼로그 띄우기 (데이터 넘김)
+                showAgreeDialog(item)
+            } else {
+                // 거절 버튼 클릭 시 -> 거절 다이얼로그 띄우기 (데이터 넘김)
+                showRefusalDialog(item)
+            }
+
+        }
+
+        // 리사이클러뷰 연결
+        binding.groupRecyclerview.apply {
+            layoutManager = LinearLayoutManager(this@GroupJoinManagementActivity)
+            adapter = groupJoinAdapter
+        }
+
+        // 초기 개수 세팅
+        updateCountText(mockData.size)
+    }
+
+    private fun updateCountText(count: Int) {
+        binding.actGrpJoinMgTitleNumTv.text = "($count)"
+    }
+
+    private fun initListener() {
+        with(binding) {
+            // 뒤로가기 버튼 기능
+            actGrpJoinMgBackIv.setOnClickListener {
+                finish()
+            }
+        }
+    }
+    // 수락 다이얼로그
+    private fun showAgreeDialog(item: GroupJoinData) {
+        val dialog = CommonDialog(
+            context = this,
+            title = "참여 요청 수락",
+            subtitle = "살인자의 기억법",
+            content = "${item.nickname} 님의 그룹 참여 요청을 수락하시겠습니까? 수락 즉시 그룹이 시작됩니다.",
+            confirmBtnText = "수락",
+            confirmBtnColor = R.color.grey_900,
+            onConfirmClick = {
+                // [확인 눌렀을 때 실행되는 진짜 로직]
+                Toast.makeText(this, "${item.nickname}님이 그룹에 추가되었습니다.", Toast.LENGTH_SHORT).show()
+
+                // 리스트에서 제거 및 개수 갱신
+                groupJoinAdapter.removeItem(item)
+                updateCountText(groupJoinAdapter.itemCount)
+            }
+        )
+        dialog.show()
+    }
+
+    // 거절 다이얼로그
+    private fun showRefusalDialog(item: GroupJoinData) {
+        val dialog = CommonDialog(
+            context = this,
+            title = "참여 요청 거절",
+            subtitle = "살인자의 기억법",
+            content = "${item.nickname} 님의 그룹 참여 요청을 거절하시겠습니까? 상대방에게 거절 알림이 발송됩니다.",
+            confirmBtnText = "거절",
+            confirmBtnColor = R.color.ui_point_red,
+            onConfirmClick = {
+                Toast.makeText(this, "요청을 거절했습니다.", Toast.LENGTH_SHORT).show()
+
+                // 리스트에서 제거 및 개수 갱신
+                groupJoinAdapter.removeItem(item)
+                updateCountText(groupJoinAdapter.itemCount)
+            }
+        )
+        dialog.show()
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GrpSearchActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GrpSearchActivity.kt
@@ -1,5 +1,6 @@
 package com.bookiibookii.bookiibookii.group
 
+import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.view.inputmethod.EditorInfo
@@ -46,10 +47,11 @@ class GrpSearchActivity : AppCompatActivity() {
             addChip(keyword)
         }
 
-        // 5. 그룹 만들기 버튼 클릭 (XML ID: act_grp_next_btn)
+        // 그룹 만들기 버튼 클릭
         binding.actGrpNextBtn.setOnClickListener {
-            Toast.makeText(this, "그룹 만들기 화면으로 이동", Toast.LENGTH_SHORT).show()
-            // TODO: 그룹 생성 화면으로 이동하는 코드 작성
+            val intent = Intent(this, GroupGenerationActivity::class.java)
+
+            startActivity(intent)
         }
     }
 
@@ -60,21 +62,20 @@ class GrpSearchActivity : AppCompatActivity() {
             isClickable = true
             isFocusable = true
 
-            // 1. 스타일 먼저 적용 (폰트 크기 등 기본 설정)
+            // 스타일 먼저 적용 (폰트 크기 등 기본 설정)
             setTextAppearance(R.style.Widget_App_Chip_Tag)
 
-            // 2. 배경 설정 (흰색)
+            // 배경 설정
             setChipBackgroundColorResource(android.R.color.white)
 
-            // 3. 테두리 설정 (시스템 회색 사용)
+            // 테두리 설정
             setChipStrokeColorResource(android.R.color.darker_gray)
             chipStrokeWidth = dpToPx(1).toFloat()
             chipCornerRadius = dpToPx(30).toFloat()
 
-            // ▼▼▼ [수정된 부분] 요청하신 컬러(#858481) 적용 ▼▼▼
             setTextColor(Color.parseColor("#858481"))
 
-            // 4. 칩 클릭 시 해당 단어로 검색
+            // 칩 클릭 시 해당 단어로 검색
             setOnClickListener {
                 binding.actGrpSearchBar.setText(text)
                 binding.actGrpSearchBar.setSelection(text.length) // 커서 맨 뒤로

--- a/app/src/main/res/layout/activity_grp_generation.xml
+++ b/app/src/main/res/layout/activity_grp_generation.xml
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:fitsSystemWindows="true">
+
+    <ImageView
+        android:id="@+id/act_grp_gen_dashBoard_Iv"
+        android:layout_width="match_parent"
+        android:layout_height="68dp"
+        android:background="@drawable/bg_grp_dashboard_border"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/act_grp_gen_back_Iv"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:src="@drawable/ic_arrow"
+        android:padding="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/act_grp_gen_dashBoard_Iv"
+        app:layout_constraintBottom_toBottomOf="@id/act_grp_gen_dashBoard_Iv"
+        android:layout_marginStart="16dp"/>
+
+    <TextView
+        android:id="@+id/act_grp_gen_main_title_Tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard_variable"
+        android:text="그룹 만들기"
+        android:textColor="@color/grey_900"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/act_grp_gen_dashBoard_Iv"
+        app:layout_constraintBottom_toBottomOf="@id/act_grp_gen_dashBoard_Iv" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/act_grp_gen_run_btn"
+        android:layout_width="0dp"
+        android:layout_height="56dp"
+        android:layout_marginHorizontal="20dp"
+        android:layout_marginBottom="20dp"
+        android:background="@drawable/bg_round_20dp_gray200"
+        android:fontFamily="@font/pretendard_variable"
+        android:text="그룹 만들기"
+        android:textColor="@color/grey_500"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:stateListAnimator="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintTop_toBottomOf="@id/act_grp_gen_dashBoard_Iv"
+        app:layout_constraintBottom_toTopOf="@id/act_grp_gen_run_btn"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="40dp">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/act_grp_gen_guideline_start"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.08" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/act_grp_gen_guideline_end"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.92" />
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_serach_Tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="도서 검색 *"
+                android:textColor="@color/grey_900"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toTopOf="parent"/>
+
+            <EditText
+                android:id="@+id/act_grp_gen_book_search_bar"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_grp_search_input"
+                android:drawableStart="@drawable/ic_search_simple"
+                android:drawablePadding="8dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:hint="검색하기"
+                android:imeOptions="actionSearch"
+                android:inputType="text"
+                android:maxLines="1"
+                android:paddingStart="12dp"
+                android:paddingEnd="16dp"
+                android:textColor="@color/black"
+                android:textColorHint="@color/grey_400"
+                android:textSize="14sp"
+                app:layout_constraintEnd_toEndOf="@id/act_grp_gen_guideline_end"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_serach_Tv" />
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_have_Tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="이 책의 실물을 가지고 계신가요? *"
+                android:textColor="@color/grey_900"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_search_bar"/>
+
+            <LinearLayout
+                android:id="@+id/act_grp_gen_btn_layout"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal"
+                android:weightSum="2"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_have_Tv"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintEnd_toEndOf="@id/act_grp_gen_guideline_end">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/act_grp_gen_book_yes_btn"
+                    android:layout_width="0dp"
+                    android:layout_height="52dp"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="6dp"
+                    android:text="네"
+                    android:textColor="@color/grey_900"
+                    app:backgroundTint="@color/white"
+                    app:cornerRadius="20dp"
+                    app:strokeColor="@color/grey_200"
+                    app:strokeWidth="1dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/act_grp_gen_book_no_btn"
+                    android:layout_width="0dp"
+                    android:layout_height="52dp"
+                    android:layout_weight="1"
+                    android:layout_marginStart="6dp"
+                    android:text="아니오"
+                    android:textColor="@color/grey_900"
+                    app:backgroundTint="@color/white"
+                    app:cornerRadius="20dp"
+                    app:strokeColor="@color/grey_200"
+                    app:strokeWidth="1dp" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_have_info_Tv"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="그룹을 생성하려면 실물 책이 필요합니다"
+                android:textColor="@color/grey_500"
+                android:textSize="12sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_btn_layout"/>
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_date_label_Tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="시작 날짜 *"
+                android:textColor="@color/grey_900"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_have_info_Tv"/>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/act_grp_gen_book_date_container"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_grp_search_input"
+                android:paddingHorizontal="16dp"
+                app:layout_constraintEnd_toEndOf="@id/act_grp_gen_guideline_end"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_date_label_Tv">
+
+                <TextView
+                    android:id="@+id/act_grp_gen_book_select_date_Tv"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:fontFamily="@font/pretendard_variable"
+                    android:maxLines="1"
+                    android:text=""
+                    tools:text="2026.01.01"
+                    android:textColor="@color/grey_900"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/act_grp_gen_book_date_Iv"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
+                    android:id="@+id/act_grp_gen_book_date_Iv"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_cal"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:tint="@color/grey_500" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_limit_info_Tv"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="독서를 시작할 날짜를 선택해주세요 (익일부터 선택 가능)"
+                android:textColor="@color/grey_500"
+                android:textSize="12sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_date_container"/>
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_limit_Tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="독서 기간 *"
+                android:textColor="@color/grey_900"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_limit_info_Tv"/>
+
+            <EditText
+                android:id="@+id/act_grp_gen_book_limit_bar"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_grp_search_input"
+                android:drawableStart="@drawable/ic_search_simple"
+                android:drawablePadding="8dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:hint="3~30"
+                android:imeOptions="actionDone"
+                android:inputType="number"
+                android:maxLines="1"
+                android:paddingStart="12dp"
+                android:paddingEnd="16dp"
+                android:textColor="@color/black"
+                android:textColorHint="@color/grey_400"
+                android:textSize="14sp"
+                app:layout_constraintEnd_toEndOf="@id/act_grp_gen_guideline_end"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_limit_Tv" />
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_limit_day_Tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="20dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="일"
+                android:textColor="@color/grey_400"
+                android:textSize="14sp"
+                app:layout_constraintBottom_toBottomOf="@id/act_grp_gen_book_limit_bar"
+                app:layout_constraintEnd_toEndOf="@id/act_grp_gen_book_limit_bar"
+                app:layout_constraintTop_toTopOf="@id/act_grp_gen_book_limit_bar" />
+
+            <TextView
+                android:id="@+id/act_grp_gen_book_limit_day_info_Tv"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="3일에서 30일 사이로 입력해주세요"
+                android:textColor="@color/grey_500"
+                android:textSize="12sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_limit_bar"/>
+
+            <TextView
+                android:id="@+id/act_grp_gen_tag_Tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="독서 태그 *"
+                android:textColor="@color/grey_900"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_book_limit_day_info_Tv"/>
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/act_grp_gen_chip_group"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                app:chipSpacingHorizontal="8dp"
+                app:chipSpacingVertical="8dp"
+                app:singleSelection="false"
+                app:layout_constraintEnd_toEndOf="@id/act_grp_gen_guideline_end"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_tag_Tv">
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/act_grp_gen_tag_memo_cp"
+                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="#메모환영"
+                    android:textColor="@color/selector_chip_category_stroke"
+                    app:chipBackgroundColor="@color/selector_chip_category_bg"
+                    app:chipStrokeColor="@color/selector_chip_category_stroke"
+                    app:chipStrokeWidth="1dp" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/act_grp_gen_tag_post_cp"
+                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="#포스트잇"
+                    android:textColor="@color/selector_chip_category_stroke"
+                    app:chipBackgroundColor="@color/selector_chip_category_bg"
+                    app:chipStrokeColor="@color/selector_chip_category_stroke"
+                    app:chipStrokeWidth="1dp"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/act_grp_gen_tag_clean_cp"
+                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="#깔끔"
+                    android:textColor="@color/selector_chip_category_stroke"
+                    app:chipBackgroundColor="@color/selector_chip_category_bg"
+                    app:chipStrokeColor="@color/selector_chip_category_stroke"
+                    app:chipStrokeWidth="1dp"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/act_grp_gen_tag_serious_cp"
+                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="#진지함"
+                    android:textColor="@color/selector_chip_category_stroke"
+                    app:chipBackgroundColor="@color/selector_chip_category_bg"
+                    app:chipStrokeColor="@color/selector_chip_category_stroke"
+                    app:chipStrokeWidth="1dp"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/act_grp_gen_tag_fun_cp"
+                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="#재미있게"
+                    android:textColor="@color/selector_chip_category_stroke"
+                    app:chipBackgroundColor="@color/selector_chip_category_bg"
+                    app:chipStrokeColor="@color/selector_chip_category_stroke"
+                    app:chipStrokeWidth="1dp"/>
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/act_grp_gen_tag_insite_cp"
+                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="#인사이트"
+                    android:textColor="@color/selector_chip_category_stroke"
+                    app:chipBackgroundColor="@color/selector_chip_category_bg"
+                    app:chipStrokeColor="@color/selector_chip_category_stroke"
+                    app:chipStrokeWidth="1dp"/>
+
+            </com.google.android.material.chip.ChipGroup>
+            <TextView
+                android:id="@+id/act_grp_gen_introduce_Tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:fontFamily="@font/pretendard_variable"
+                android:text="그룹 소개"
+                android:textColor="@color/grey_900"
+                android:textSize="16sp"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_chip_group"/>
+
+            <EditText
+                android:id="@+id/act_grp_gen_introduce_bar"
+                android:layout_width="0dp"
+                android:layout_height="128dp"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_grp_search_input"
+                android:fontFamily="@font/pretendard_variable"
+                android:gravity="top|start"
+                android:hint="독서 성향 태그에서 추가적으로 설명이 필요한 대목을 적어라!!\n ex. 낙서 절대 금지"
+                android:inputType="textMultiLine"
+                android:padding="12dp"
+                android:textColor="@color/black"
+                android:textColorHint="@color/grey_400"
+                android:textSize="14sp"
+                app:layout_constraintEnd_toEndOf="@id/act_grp_gen_guideline_end"
+                app:layout_constraintStart_toStartOf="@id/act_grp_gen_guideline_start"
+                app:layout_constraintTop_toBottomOf="@id/act_grp_gen_introduce_Tv" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_grp_join_management.xml
+++ b/app/src/main/res/layout/activity_grp_join_management.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/ui_bg"
+    android:fitsSystemWindows="false">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.08" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.92" />
+
+
+    <ImageView
+        android:id="@+id/act_grp_join_mg_dashBoard_Iv"
+        android:layout_width="match_parent"
+        android:layout_height="68dp"
+        android:background="@drawable/bg_grp_dashboard_border"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/act_grp_join_mg_back_Iv"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:src="@drawable/ic_arrow"
+        android:padding="8dp"
+        app:layout_constraintStart_toStartOf="@id/guideline_start"
+        app:layout_constraintTop_toTopOf="@id/act_grp_join_mg_dashBoard_Iv"
+        app:layout_constraintBottom_toBottomOf="@id/act_grp_join_mg_dashBoard_Iv" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        app:layout_constraintTop_toTopOf="@id/act_grp_join_mg_dashBoard_Iv"
+        app:layout_constraintBottom_toBottomOf="@id/act_grp_join_mg_dashBoard_Iv"
+        app:layout_constraintStart_toStartOf="@id/act_grp_join_mg_dashBoard_Iv"
+        app:layout_constraintEnd_toEndOf="@id/act_grp_join_mg_dashBoard_Iv">
+
+        <TextView
+            android:id="@+id/act_grp_join_mg_title_Tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_variable"
+            android:text="참여 요청 관리"
+            android:textColor="@color/grey_900"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/act_grp_join_mg_title_num_Tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:fontFamily="@font/pretendard_variable"
+            tools:text="(5)"
+            android:textColor="@color/grey_900"
+            android:textSize="20sp" />
+
+    </LinearLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/group_recyclerview"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="20dp"
+        android:clipToPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guideline_end"
+        app:layout_constraintStart_toStartOf="@id/guideline_start"
+        app:layout_constraintTop_toBottomOf="@id/act_grp_join_mg_dashBoard_Iv"
+        tools:listitem="@layout/item_group_join_management" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_common.xml
+++ b/app/src/main/res/layout/dialog_common.xml
@@ -5,15 +5,14 @@
     android:layout_width="340dp"
     android:layout_height="wrap_content"
     android:background="@drawable/bg_round_24dp_white"
-
     android:padding="24dp">
 
     <TextView
-        android:id="@+id/dialog_delete_title_Tv"
+        android:id="@+id/dialog_title_tv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:fontFamily="@font/pretendard_variable"
-        android:text="그룹 삭제"
+        tools:text="타이틀 영역"
         android:textStyle="bold"
         android:textColor="@color/grey_900"
         android:textSize="20sp"
@@ -21,42 +20,41 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
-        android:id="@+id/dialog_delete_close_Iv"
+        android:id="@+id/dialog_close_iv"
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:src="@drawable/ic_close_round"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/dialog_delete_title_Tv"
-        app:layout_constraintBottom_toBottomOf="@id/dialog_delete_title_Tv"/>
+        app:layout_constraintTop_toTopOf="@id/dialog_title_tv"
+        app:layout_constraintBottom_toBottomOf="@id/dialog_title_tv"/>
 
     <TextView
-        android:id="@+id/dialog_delete_info_Tv"
+        android:id="@+id/dialog_subtitle_tv"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:fontFamily="@font/pretendard_variable"
-        android:text="괴테는 모든 것을 말했다"
-        android:textColor="@color/grey_900"
+        tools:text="서브타이틀"
+        android:textColor="@color/grey_800"
         android:layout_marginTop="4dp"
         android:textSize="16sp"
-        app:layout_constraintStart_toStartOf="@id/dialog_delete_title_Tv"
-        app:layout_constraintTop_toBottomOf="@id/dialog_delete_title_Tv" />
+        app:layout_constraintStart_toStartOf="@id/dialog_title_tv"
+        app:layout_constraintTop_toBottomOf="@id/dialog_title_tv" />
 
     <TextView
-        android:id="@+id/dialog_delete_warning_Tv"
+        android:id="@+id/dialog_content_tv"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
         android:fontFamily="@font/pretendard_variable"
-        android:text="그룹을 정말 삭제하시겠습니까?이 작업은 되돌릴 수 없습니다."
-        android:textColor="@color/grey_600"
-        android:textSize="14sp"
+        tools:text="본문 내용이 들어갑니다."
+        android:textColor="@color/grey_700"
+        android:textSize="16sp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/dialog_delete_info_Tv" />
-
+        app:layout_constraintTop_toBottomOf="@id/dialog_subtitle_tv" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/dialog_delete_cancel_btn"
+        android:id="@+id/dialog_cancel_btn"
         android:layout_width="140dp"
         android:layout_height="48dp"
         android:fontFamily="@font/pretendard_variable"
@@ -67,22 +65,22 @@
         app:cornerRadius="16dp"
         app:strokeColor="@color/grey_200"
         app:strokeWidth="1dp"
-        app:layout_constraintTop_toBottomOf="@id/dialog_delete_warning_Tv"
+        app:layout_constraintTop_toBottomOf="@id/dialog_content_tv"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
-        app:layout_constraintStart_toStartOf="@id/dialog_delete_warning_Tv" />
+        app:layout_constraintStart_toStartOf="@id/dialog_content_tv" />
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/dialog_delete_enter_btn"
+        android:id="@+id/dialog_confirm_btn"
         android:layout_width="140dp"
         android:layout_height="48dp"
         android:fontFamily="@font/pretendard_variable"
         android:layout_marginStart="12dp"
-        android:text="삭제"
+        tools:text="확인"
+        tools:backgroundTint="@color/grey_900"
         android:textColor="@color/white"
-        app:backgroundTint="@color/ui_point_red"
         app:cornerRadius="16dp"
-        app:layout_constraintTop_toTopOf="@id/dialog_delete_cancel_btn"
+        app:layout_constraintTop_toTopOf="@id/dialog_cancel_btn"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
-        app:layout_constraintStart_toEndOf="@id/dialog_delete_cancel_btn"/>
+        app:layout_constraintStart_toEndOf="@id/dialog_cancel_btn"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_grp.xml
+++ b/app/src/main/res/layout/fragment_grp.xml
@@ -128,6 +128,7 @@
         app:layout_constraintStart_toStartOf="@id/guideline_start"
         app:layout_constraintTop_toBottomOf="@id/grp_main_dashBoard_Iv"
         tools:listitem="@layout/item_grp_card" />
+
     <ImageView
         android:id="@+id/grp_group_list_Iv"
         android:layout_width="56dp"

--- a/app/src/main/res/layout/item_group_join_management.xml
+++ b/app/src/main/res/layout/item_group_join_management.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_round_24dp_white"
+    android:padding="24dp"
+    android:layout_marginBottom="16dp">
+
+    <ImageView
+        android:id="@+id/item_grp_join_manage_profile_Iv"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:src="@drawable/ic_profile"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/item_grp_join_manage_nickname_Tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard_variable"
+        android:textSize="16sp"
+        android:textColor="@color/black"
+        android:layout_marginStart="12dp"
+       app:layout_constraintTop_toTopOf="@id/item_grp_join_manage_profile_Iv"
+        app:layout_constraintStart_toEndOf="@id/item_grp_join_manage_profile_Iv"
+        android:text="kanghunsim" />
+
+    <TextView
+        android:id="@+id/item_grp_join_manage_date_Tv"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard_variable"
+        android:textSize="12sp"
+        android:textColor="@color/grey_400"
+
+        app:layout_constraintTop_toBottomOf="@id/item_grp_join_manage_nickname_Tv"
+        app:layout_constraintStart_toStartOf="@id/item_grp_join_manage_nickname_Tv"
+        app:layout_constraintBottom_toBottomOf="@id/item_grp_join_manage_profile_Iv"
+        android:text="2025.12.05." />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/grp_item_join_mg_hash1_Cp"
+        style="@style/Widget.App.Chip.hashtag"
+        android:layout_width="wrap_content"
+        android:layout_height="23dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="16dp"
+        android:text="#메모환영"
+        app:layout_constraintStart_toStartOf="@id/item_grp_join_manage_profile_Iv"
+        app:layout_constraintTop_toBottomOf="@id/item_grp_join_manage_profile_Iv" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/grp_item_join_mg_hash2_Cp"
+        style="@style/Widget.App.Chip.hashtag"
+        android:layout_width="wrap_content"
+        android:layout_height="23dp"
+        android:layout_marginStart="8dp"
+        android:text="#인사이트"
+        app:layout_constraintStart_toEndOf="@id/grp_item_join_mg_hash1_Cp"
+        app:layout_constraintTop_toTopOf="@id/grp_item_join_mg_hash1_Cp" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/grp_item_join_mg_hash3_Cp"
+        style="@style/Widget.App.Chip.hashtag"
+        android:layout_width="wrap_content"
+        android:layout_height="23dp"
+        android:layout_marginStart="8dp"
+        android:text="#깔끔"
+        app:layout_constraintStart_toEndOf="@id/grp_item_join_mg_hash2_Cp"
+        app:layout_constraintTop_toTopOf="@id/grp_item_join_mg_hash1_Cp" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/grp_item_join_mg_hash4_Cp"
+        style="@style/Widget.App.Chip.hashtag"
+        android:layout_width="wrap_content"
+        android:layout_height="23dp"
+        android:layout_marginStart="8dp"
+        android:text="#태그"
+        app:layout_constraintStart_toEndOf="@id/grp_item_join_mg_hash3_Cp"
+        app:layout_constraintTop_toTopOf="@id/grp_item_join_mg_hash1_Cp" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/grp_item_join_mg_hash5_Cp"
+        style="@style/Widget.App.Chip.hashtag"
+        android:layout_width="wrap_content"
+        android:layout_height="23dp"
+        android:layout_marginStart="8dp"
+        android:text="#태그"
+        app:layout_constraintStart_toEndOf="@id/grp_item_join_mg_hash4_Cp"
+        app:layout_constraintTop_toTopOf="@id/grp_item_join_mg_hash1_Cp" />
+
+    <TextView
+        android:id="@+id/item_grp_join_manage_content_Tv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/grey_600"
+        android:layout_marginTop="12dp"
+        android:textSize="14sp"
+        android:fontFamily="@font/pretendard_variable"
+        android:padding="12dp"
+        android:text="저 너무 참여하고 싶은데 혹시 3일만 이따가 시작해도 될까요 ~~ㅠㅠ??"
+        android:background="@drawable/bg_round_16dp_gray100"
+        app:layout_constraintStart_toStartOf="@id/item_grp_join_manage_profile_Iv"
+        app:layout_constraintTop_toBottomOf="@id/grp_item_join_mg_hash1_Cp"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/item_grp_join_manage_no_btn"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:fontFamily="@font/pretendard_variable"
+        android:layout_marginTop="20dp"
+        android:text="거절"
+        android:textColor="@color/grey_900"
+        app:backgroundTint="@color/grey_200"
+        app:cornerRadius="16dp"
+        app:strokeColor="@color/grey_200"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/item_grp_join_manage_content_Tv"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+        app:layout_constraintStart_toStartOf="@id/item_grp_join_manage_content_Tv"
+        app:layout_constraintEnd_toStartOf="@id/item_grp_join_manage_yes_btn"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/item_grp_join_manage_yes_btn"
+        android:layout_width="0dp"
+        android:layout_height="48dp"
+        android:fontFamily="@font/pretendard_variable"
+        android:layout_marginStart="12dp"
+        android:text="수락"
+        android:textColor="@color/grey_100"
+        app:backgroundTint="@color/grey_900"
+        app:cornerRadius="16dp"
+        app:layout_constraintTop_toTopOf="@id/item_grp_join_manage_no_btn"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+        app:layout_constraintStart_toEndOf="@id/item_grp_join_manage_no_btn"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# 📌 Pull Request Title
> **`<ui>`: `<그룹 UI 완성>`**


---

# ✨ 작업 내용 (What)
HOST MODE -> 참여관리 클릭 시 UI -> 취소 / 수락 버튼 구현(API 동작은 안했슴다)
<img width="299" height="660" alt="image" src="https://github.com/user-attachments/assets/88eafc2d-557d-4b93-8c26-e7e52b52611c" />

<img width="277" height="212" alt="스크린샷 2026-01-29 오후 3 34 50" src="https://github.com/user-attachments/assets/efa7a388-3e67-4df5-9d1a-b39577a7a837" />

<img width="273" height="196" alt="image" src="https://github.com/user-attachments/assets/56c95ebb-3752-4995-b18a-bf4853fd4de5" />

그룹만들기 UI 완성
<img width="301" height="663" alt="image" src="https://github.com/user-attachments/assets/e0369d8a-5b5b-4794-b567-9d6f1a16f4af" />

날짜 선택도 가능하게 구현은 했는데, 커스텀 여부는 확인해봐야함
<img width="288" height="441" alt="image" src="https://github.com/user-attachments/assets/a6ca2030-3583-4f26-8d9f-835d64cc3536" />

책 미소유시 구매 버튼 연계
<img width="298" height="309" alt="image" src="https://github.com/user-attachments/assets/5f5ec636-7558-4c6d-94fd-bae5615650f5" />

---

# 🧪 테스트 방법 (How to Test)

- RUN 진행 간 정상 작동 확인!!

---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!

- manifest에 엑티비티 정의할 때 무조건 충돌 날거 같은데, 그거는 해결해야할 숙제입니다..
- UI 최종본이랑 약간 다른게 많을텐데, 그건 대대적인 수정을 진행하도록 하겠습니다.......
- 추가로 Dialog 공통으로 사용가능할 것 같아서 common에 작성해두었습니다!! 재활용가능하면 사용해주세요
---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #41 
