### PR TITLE
refactor: Group Fragment NPE 현상 해결(#99)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupFragment.kt
@@ -20,6 +20,7 @@ class GroupFragment : Fragment() {
     private var _binding: FragmentGrpBinding? = null
     private val binding get() = _binding!!
 
+    private var isLoading = false
     private var isFabOpen = false
 
     // 필터 상태 관리 변수 (기본값: 전체)
@@ -60,6 +61,12 @@ class GroupFragment : Fragment() {
     }
 
     private fun loadGroupData() {
+
+        if (isLoading) return
+
+        // [2] 로딩 시작! 깃발 들기
+        isLoading = true
+
         val allData = getDummyData()
 
         // 1. 그룹 유형 필터링
@@ -87,14 +94,22 @@ class GroupFragment : Fragment() {
             }
         }
 
-        // 3. 결과 반영 (로딩 딜레이 시뮬레이션)
-        // 여기서 NPE 에러 발생하는 거 같음. 일단 수정은 안함
         Handler(Looper.getMainLooper()).postDelayed({
+            // ★ 0.5초 뒤에 눈을 떴는데 화면이 죽어있다면?
+            if (_binding == null) {
+                isLoading = false
+                return@postDelayed
+            }
+            // 어댑터 연결 및 UI 업데이트
             val groupAdapter = GroupAdapter(ArrayList(filteredData)) { groupData ->
                 moveToDetail(groupData)
             }
             binding.groupRecyclerview.adapter = groupAdapter
+            // 새로고침 아이콘 끄기
             binding.grpSwipeRefreshLayout.isRefreshing = false
+            // [4] 작업 끝! 로딩 상태 해제 (이제 다시 클릭 가능)
+            isLoading = false
+
         }, 500)
     }
 


### PR DESCRIPTION
# 📌 Pull Request Title
> **`<refactor>`: `<Group Fragment NPE 현상 해결>`**

---

# ✨ 작업 내용 (What)

- 그룹 데이터 리프레쉬과정(0.5초) 내에서 조회 연타 시 NPE 발생.
- 방패막 및 안전장치 설치 완료
- 실제 Run 간 양호 확인
![9CFD2920-FB4B-41EB-BF30-8D719C8D89F3_4_5005_c](https://github.com/user-attachments/assets/fa3a62c8-51d1-4c65-a715-2ee52838861a)

￼

---

# 🧪 테스트 방법 (How to Test)

> - 앱 실행 → 그룹화면 연타 -> 앱튕김 없음 확인

---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #99 
