### PR TITLE
fix: 온보딩 완료 상태 저장 및 자동 로그인 흐름 개선 (#108)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/MainActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.bookiibookii.bookiibookii
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -23,6 +24,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // TODO: 온보딩까지 구현 후 삭제
+        Log.d("ONB_FLOW", "MainActivity started")
 
 //        enableEdgeToEdge()
 //        setContentView(R.layout.activity_main)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/AuthModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/AuthModel.kt
@@ -23,7 +23,6 @@ data class LoginResult(
     val accessToken: String,
     val refreshToken: String,
     val userId: Int,
-    val nickname: String // 임시 닉네임 -> 추후 삭제 필요
 )
 
 data class UserUpdateRequest(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/LoginActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/LoginActivity.kt
@@ -19,6 +19,7 @@ import com.bookiibookii.bookiibookii.MainActivity
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.data.api.RetrofitClient
 import com.bookiibookii.bookiibookii.data.model.LoginRequest
+import com.bookiibookii.bookiibookii.onboarding.profile.OnbProfileActivity
 import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.material.card.MaterialCardView
@@ -36,11 +37,19 @@ class LoginActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // TODO: 온보딩까지 구현 후 삭제
+        Log.d("ONB_FLOW", "token=${hasAccessToken()} done=${isOnboardingDone()}")
+
         setContentView(R.layout.activity_login)
 
         // 1. 자동 로그인 체크 (토큰이 이미 있으면 메인으로)
         if (hasAccessToken()) {
-            moveToMain()
+            if (isOnboardingDone()) {
+                moveToMain()
+            } else {
+                moveToOnboarding()
+            }
             return
         }
 
@@ -51,11 +60,6 @@ class LoginActivity : AppCompatActivity() {
         Log.e("APP_CHECK", "MyApplication onCreate called")
 
         Log.e("KeyHash_Check", "내 앱의 현재 키 해시: $keyHash")
-
-        findViewById<View>(R.id.btn_kakao_login).setOnClickListener {
-            loginToKakao()
-        }
-
     }
 
     private fun setupLoginButtons() {
@@ -172,8 +176,11 @@ class LoginActivity : AppCompatActivity() {
     // --- 유틸리티 함수들 ---
 
     private fun onLoginSuccess() {
-
-        moveToMain()
+        if (isOnboardingDone()) {
+            moveToMain()
+        } else {
+            moveToOnboarding()
+        }
     }
 
     private fun showLoadingState(isLoading: Boolean) {
@@ -211,6 +218,11 @@ class LoginActivity : AppCompatActivity() {
             putInt("user_id", userId)
             apply()
         }
+    }
+
+    private fun isOnboardingDone(): Boolean {
+        val prefs = getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+        return prefs.getBoolean("onboarding_done", false)
     }
 
     private fun hasAccessToken(): Boolean {
@@ -264,6 +276,13 @@ class LoginActivity : AppCompatActivity() {
     // 메인 화면으로 이동하는 함수
     private fun moveToMain() {
         val intent = Intent(this, MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        finish()
+    }
+
+    private fun moveToOnboarding() {
+        val intent = Intent(this, OnbProfileActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         startActivity(intent)
         finish()

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStatusActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStatusActivity.kt
@@ -2,6 +2,7 @@ package com.bookiibookii.bookiibookii.onboarding.steps
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
@@ -84,9 +85,23 @@ class OnbStatusActivity : AppCompatActivity() {
 
         // 완료 화면에서 하단 버튼 클릭 시 메인 화면으로 이동
         btnFooter.setOnClickListener {
-            startActivity(Intent(this, MainActivity::class.java))
+            setOnboardingDone()
+
+            // TODO: 온보딩까지 구현 후 삭제
+            Log.d("ONB_FLOW", "saved onboarding_done=true")
+
+            val intent = Intent(this, MainActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
             finish()
         }
+    }
+
+    private fun setOnboardingDone() {
+        val prefs = getSharedPreferences("auth_prefs", MODE_PRIVATE)
+        prefs.edit()
+            .putBoolean("onboarding_done", true)
+            .apply()
     }
 
     // 현재 상태에 따라 로딩 화면 / 완료 화면 분기 처리

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
@@ -147,6 +147,13 @@ class OnbStepActivity : AppCompatActivity() {
         btnNext.text = "다음"
     }
 
+    private fun setOnboardingDone() {
+        val prefs = getSharedPreferences("auth_prefs", MODE_PRIVATE)
+        prefs.edit()
+            .putBoolean("onboarding_done", true)
+            .apply()
+    }
+
     // 현재 단계에서 "다음" 버튼을 활성화할 수 있는지 판단
     private fun updateNextButtonState() {
         btnNext.isEnabled = when (currentStep) {


### PR DESCRIPTION
# 📌 Pull Request Title
fix: 온보딩 완료 상태 저장 및 자동 로그인 흐름 개선 

---

# ✨ 작업 내용 (What)
- 소셜 로그인 성공 시 onboarding_done 여부에 따라 메인/온보딩 분기 처리
- SharedPreferences 기반 onboarding_done 상태 저장 및 유지 로직 구현
- 온보딩 완료 후 Status 화면에서 완료 상태 저장 후 메인 이동
- 앱 재실행 시 자동 로그인 + 온보딩 완료 여부 정상 분기 확인
- 디버깅 로그 추가로 로그인/온보딩 플로우 검증

---

# 🧪 테스트 방법 (How to Test)
1. 앱 최초 실행
2. 카카오 또는 구글 로그인 진행
   - 로그인 성공 후 온보딩 프로필 화면으로 이동 확인
3. 온보딩 전체 단계 완료 → Status 완료 화면에서 [시작하기] 버튼 클릭
   - 메인 화면으로 이동 확인
4. 앱 완전 종료 후 재실행
   - 로그인 화면을 거치지 않고 메인 화면으로 바로 진입하는지 확인

---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #108
