### PR TITLE
ui: 바텀 네비게이션 레이아웃 구조 및 여백 개선 (#117)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/ApiService.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/ApiService.kt
@@ -1,5 +1,6 @@
 package com.bookiibookii.bookiibookii.data.api
 
+import com.bookiibookii.bookiibookii.data.model.CommonResponse
 import com.bookiibookii.bookiibookii.data.model.GroupMemberResponse
 import com.bookiibookii.bookiibookii.data.model.InquiryCreateResponse
 import com.bookiibookii.bookiibookii.data.model.InquiryListResponse
@@ -9,8 +10,11 @@ import com.bookiibookii.bookiibookii.data.model.LoginResponse
 import com.bookiibookii.bookiibookii.data.model.LogoutResponse
 import com.bookiibookii.bookiibookii.data.model.MyGroupResponse
 import com.bookiibookii.bookiibookii.data.model.MypageResponse
+import com.bookiibookii.bookiibookii.data.model.NicknameValidationResponse
 import com.bookiibookii.bookiibookii.data.model.NoticeDetailResponse
 import com.bookiibookii.bookiibookii.data.model.NoticeListResponse
+import com.bookiibookii.bookiibookii.data.model.OnboardingRequest
+import com.bookiibookii.bookiibookii.data.model.PresignedUrlResponse
 import com.bookiibookii.bookiibookii.data.model.ReportCreateResponse
 import com.bookiibookii.bookiibookii.data.model.ReportListResponse
 import com.bookiibookii.bookiibookii.data.model.ReportRequest
@@ -26,6 +30,7 @@ import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface ApiService {
 
@@ -80,6 +85,22 @@ interface ApiService {
     suspend fun getGroupMembers(
         @Path("groupId") groupId: Int
     ): Response<GroupMemberResponse>
+
+    // 닉네임 중복 검증
+    @POST("api/users/name-validation")
+    suspend fun postNicknameValidation(
+        @Query("nickname") nickname: String
+    ): Response<NicknameValidationResponse>
+
+    // 사용자 이미지 업로드용 Presigned URL 발급
+    @POST("api/users/me/image/presigned-url")
+    suspend fun postPresignedUrl(): Response<PresignedUrlResponse>
+
+    // 온보딩 기능 API
+    @POST("/api/onboarding")
+    suspend fun postOnboarding(
+        @Body body: OnboardingRequest
+    ): retrofit2.Response<CommonResponse<String>>
 }
 
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/S3Uploader.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/S3Uploader.kt
@@ -1,0 +1,41 @@
+package com.bookiibookii.bookiibookii.data.api
+
+import android.content.ContentResolver
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+object S3Uploader {
+
+    // Presigned URL 업로드는 Authorization 인터셉터가 없어야 안전
+    private val client = OkHttpClient()
+
+    suspend fun uploadImage(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        presignedPutUrl: String
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val mime = contentResolver.getType(uri) ?: "application/octet-stream"
+            val bytes = contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                ?: error("이미지 파일을 불러오지 못했습니다.")
+
+            val requestBody = bytes.toRequestBody(mime.toMediaTypeOrNull())
+            val request = Request.Builder()
+                .url(presignedPutUrl)
+                .put(requestBody)
+                .addHeader("Content-Type", mime)
+                .build()
+
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    error("S3 업로드 실패: HTTP ${response.code}")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/CommonResponse.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/CommonResponse.kt
@@ -1,0 +1,8 @@
+package com.bookiibookii.bookiibookii.data.model
+
+data class CommonResponse<T>(
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String,
+    val result: T?
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/OnbModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/OnbModel.kt
@@ -1,0 +1,12 @@
+package com.bookiibookii.bookiibookii.data.model
+
+data class OnboardingRequest(
+    val name: String,
+    val tags: List<OnboardingTag>,
+    val s3Key: String?
+)
+
+data class OnboardingTag(
+    val type: String,
+    val value: List<String>
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/UserModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/UserModel.kt
@@ -1,0 +1,26 @@
+package com.bookiibookii.bookiibookii.data.model
+
+// 1) 닉네임 중복 확인
+data class NicknameValidationResponse(
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String,
+    val result: NicknameValidationResult?
+)
+
+data class NicknameValidationResult(
+    val isAvailable: Boolean
+)
+
+// 2) Presigned URL
+data class PresignedUrlResponse(
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String,
+    val result: PresignedUrlResult?
+)
+
+data class PresignedUrlResult(
+    val s3Key: String,
+    val presignedPutUrl: String
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinManagemnetActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupJoinManagemnetActivity.kt
@@ -3,7 +3,6 @@ package com.bookiibookii.bookiibookii.group
 import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
-import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -58,7 +57,7 @@ class GroupJoinManagementActivity : AppCompatActivity() {
     // 커스텀 토스트 띄우기 함수
     private fun showCustomToast(message: String) {
         val inflater = LayoutInflater.from(this)
-        val layout = inflater.inflate(R.layout.toast_costom, null)
+        val layout = inflater.inflate(R.layout.toast_custom, null)
 
         // 텍스트 설정
         val textView = layout.findViewById<TextView>(R.id.toast_message_tv)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/NicknameCheckState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/NicknameCheckState.kt
@@ -1,0 +1,9 @@
+package com.bookiibookii.bookiibookii.onboarding.profile
+
+sealed class NicknameCheckState {
+    data object Idle : NicknameCheckState()
+    data object Loading : NicknameCheckState()
+    data class Available(val message: String) : NicknameCheckState()
+    data class Duplicated(val message: String) : NicknameCheckState()
+    data class Error(val message: String) : NicknameCheckState()
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileActivity.kt
@@ -3,14 +3,18 @@ package com.bookiibookii.bookiibookii.onboarding.profile
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.Gravity
 import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.core.graphics.toColorInt
 import androidx.core.widget.addTextChangedListener
-import com.bookiibookii.bookiibookii.MainActivity
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.databinding.ActivityOnbProfileBinding
 import com.bookiibookii.bookiibookii.onboarding.steps.OnbStepActivity
@@ -20,14 +24,19 @@ class OnbProfileActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityOnbProfileBinding
 
-    // 중복 확인 완료 여부
+    private val viewModel: OnbProfileViewModel by viewModels()
+
+    // 닉네임 중복 확인 완료 여부
     private var isNicknameChecked = false
 
-    // 카메라 촬영용 임시 Uri
+    // 카메라 촬영 결과 Uri
     private var cameraImageUri: Uri? = null
 
-    // 서비스 금칙어
-    // TODO: 임시 (API 연동 시 삭제)
+    // 업로드 완료된 프로필 이미지 S3 Key
+    private var uploadedS3Key: String? = null
+
+    // 서비스 금칙어 (임시)
+    // TODO: API 연동 후 삭제
     private val bannedWords = listOf(
         "관리자",
         "admin",
@@ -39,19 +48,28 @@ class OnbProfileActivity : AppCompatActivity() {
         "shit"
     )
 
-    // 갤러리(포토피커) 런처: 권한 없이 동작
+    // 갤러리 이미지 선택 런처 (권한 불필요)
     private val pickImageLauncher =
         registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
             if (uri != null) {
                 binding.ivProfile.setImageURI(uri)
+                viewModel.uploadProfileImage(contentResolver, uri)
             }
         }
 
-    // 카메라 촬영 런처: 촬영 성공 시 Uri 반영
+    // 카메라 촬영 런처
     private val takePictureLauncher =
         registerForActivityResult(ActivityResultContracts.TakePicture()) { success ->
+            // TODO: 디버그 로그 제거
+            android.util.Log.d("IMG_UI", "takePicture success=$success, uri=$cameraImageUri")
+
             if (success) {
-                cameraImageUri?.let { binding.ivProfile.setImageURI(it) }
+                cameraImageUri?.let {
+                    binding.ivProfile.setImageURI(it)
+                    // TODO: 디버그 로그 제거
+                    android.util.Log.d("IMG_UI", "call uploadProfileImage uri=$it")
+                    viewModel.uploadProfileImage(contentResolver, it)
+                }
             }
         }
 
@@ -62,8 +80,10 @@ class OnbProfileActivity : AppCompatActivity() {
 
         initView()
         initListeners()
+        observeViewModel()
     }
 
+    // 초기 UI 상태 설정
     private fun initView() {
         binding.btnCheck.isEnabled = false
         binding.includeFooterButton.btnFooter.isEnabled = false
@@ -72,48 +92,41 @@ class OnbProfileActivity : AppCompatActivity() {
 
     private fun initListeners() {
 
-        // 닉네임 입력 변경: 실시간은 "버튼 활성/비활성" 중심으로만 처리
+        // 닉네임 입력 변경 시 버튼 상태 초기화
         binding.etNickname.addTextChangedListener { text ->
             val nickname = text?.toString().orEmpty()
 
-            // 입력이 바뀌면 이전 중복확인 결과는 무효
+            // 입력 변경 시 중복 확인 상태 초기화
             isNicknameChecked = false
             binding.includeFooterButton.btnFooter.isEnabled = false
-
-            // 입력 중에는 하단 메시지 숨김(다시 검증 필요)
             binding.layoutValidation.visibility = View.GONE
 
-            // 형식이 유효할 때만 중복확인 버튼 활성화
-            binding.btnCheck.isEnabled = validateNicknameInput(nickname) == NicknameInputState.VALID
+            // 형식이 유효한 경우에만 중복 확인 버튼 활성화
+            binding.btnCheck.isEnabled =
+                validateNicknameInput(nickname) == NicknameInputState.VALID
         }
 
-        // 중복확인 버튼 클릭: 형식 -> 금칙어 -> 중복 순서로 검증
+        // 닉네임 중복 확인 버튼 클릭
         binding.btnCheck.setOnClickListener {
-            val nickname = binding.etNickname.text.toString()
+            val nickname = binding.etNickname.text.toString().trim()
 
-            // 1) 형식 검증
+            // 형식 검증
             if (validateNicknameInput(nickname) != NicknameInputState.VALID) {
                 showError("허용되지 않은 문자가 포함되어 있습니다.")
                 return@setOnClickListener
             }
 
-            // 2) 금칙어 검증
+            // 금칙어 검증
             if (containsBannedWord(nickname)) {
                 showError("금칙어가 포함되어 있습니다.")
                 return@setOnClickListener
             }
 
-            // 3) 중복 확인 (TODO: API로 교체)
-            val isAvailable = checkNicknameDummy(nickname)
-
-            if (isAvailable) {
-                showSuccess("사용 가능한 닉네임입니다.")
-            } else {
-                showError("이미 존재하는 닉네임입니다.")
-            }
+            // 서버 중복 확인 요청
+            viewModel.checkNickname(nickname)
         }
 
-        // 카메라 버튼 클릭(프로필 수정) -> BottomSheet 노출
+        // 프로필 이미지 수정 버튼 클릭
         binding.ivProfileEdit.setOnClickListener {
             OnbProfileBottomSheet(object : OnbProfileBottomSheet.Listener {
                 override fun onClickCamera() {
@@ -130,10 +143,78 @@ class OnbProfileActivity : AppCompatActivity() {
         binding.includeFooterButton.btnFooter.setOnClickListener {
             if (!isNicknameChecked) return@setOnClickListener
 
-            startActivity(Intent(this, OnbStepActivity::class.java))
+            val nickname = binding.etNickname.text.toString().trim()
+
+            startActivity(
+                Intent(this, OnbStepActivity::class.java)
+                    .putExtra(OnbStepActivity.EXTRA_NAME, nickname)
+                    .putExtra(OnbStepActivity.EXTRA_S3_KEY, uploadedS3Key)
+            )
         }
     }
 
+    // ViewModel 상태 관찰
+    private fun observeViewModel() {
+        viewModel.nicknameState.observe(this) { state ->
+            when (state) {
+                NicknameCheckState.Idle -> Unit
+
+                NicknameCheckState.Loading -> {
+                    binding.btnCheck.isEnabled = false
+                    binding.includeFooterButton.btnFooter.isEnabled = false
+                    binding.layoutValidation.visibility = View.GONE
+                }
+
+                is NicknameCheckState.Available -> {
+                    enableCheckButtonIfValid()
+                    showSuccess(state.message)
+                }
+
+                is NicknameCheckState.Duplicated -> {
+                    enableCheckButtonIfValid()
+                    showError(state.message)
+                }
+
+                is NicknameCheckState.Error -> {
+                    enableCheckButtonIfValid()
+                    showError(state.message)
+                }
+            }
+        }
+
+        viewModel.imageUploadState.observe(this) { state ->
+            when (state) {
+                ProfileImageUploadState.Idle -> Unit
+
+                ProfileImageUploadState.Loading -> {
+                    binding.ivProfileEdit.isEnabled = false
+                    binding.includeFooterButton.btnFooter.isEnabled = false
+                }
+
+                is ProfileImageUploadState.Success -> {
+                    uploadedS3Key = state.s3Key
+                    binding.ivProfileEdit.isEnabled = true
+                    binding.includeFooterButton.btnFooter.isEnabled = isNicknameChecked
+                    showCustomToast("프로필 이미지가 업로드되었습니다.")
+                }
+
+                is ProfileImageUploadState.Error -> {
+                    binding.ivProfileEdit.isEnabled = true
+                    binding.includeFooterButton.btnFooter.isEnabled = isNicknameChecked
+                    showCustomToast(message = state.message)
+                }
+            }
+        }
+    }
+
+    // 닉네임이 유효한 경우 중복 확인 버튼 활성화
+    private fun enableCheckButtonIfValid() {
+        val nickname = binding.etNickname.text?.toString()?.trim().orEmpty()
+        binding.btnCheck.isEnabled =
+            validateNicknameInput(nickname) == NicknameInputState.VALID
+    }
+
+    // 닉네임 사용 가능 UI 처리
     private fun showSuccess(message: String) {
         isNicknameChecked = true
 
@@ -149,6 +230,7 @@ class OnbProfileActivity : AppCompatActivity() {
         binding.includeFooterButton.btnFooter.isEnabled = true
     }
 
+    // 닉네임 오류 UI 처리
     private fun showError(message: String) {
         isNicknameChecked = false
 
@@ -164,45 +246,45 @@ class OnbProfileActivity : AppCompatActivity() {
         binding.includeFooterButton.btnFooter.isEnabled = false
     }
 
-    // TODO: 실제 API 연결 시 제거 예정
-    private fun checkNicknameDummy(nickname: String): Boolean {
-        val duplicated = listOf("admin", "test", "bookii")
-        return !duplicated.contains(nickname.lowercase())
-    }
-
-    // 금칙어 포함 여부: 부분 포함도 차단
+    // 금칙어 포함 여부 확인
     private fun containsBannedWord(nickname: String): Boolean {
         val lower = nickname.lowercase()
         return bannedWords.any { banned -> lower.contains(banned.lowercase()) }
     }
 
-    // 요구사항: 한글/영문/숫자 + 지정 특수문자만 허용, 공백/이모지 제한, 10자 제한
+    // 닉네임 형식 검증
     private fun validateNicknameInput(nickname: String): NicknameInputState {
         if (nickname.isBlank()) return NicknameInputState.EMPTY
         if (nickname.length > 10) return NicknameInputState.INVALID
         if (nickname.any { it.isWhitespace() }) return NicknameInputState.INVALID
 
-        // 허용 특수문자: . - _ / ( ) [ ] : ! ?
+        // 허용 문자 정규식
         val allowedRegex = Regex("^[가-힣A-Za-z0-9._\\-\\/\\(\\)\\[\\]:!?]+$")
 
-        // 이모지/서로게이트(대부분의 이모지) 차단
+        // 이모지(서로게이트 문자) 차단
         if (nickname.any { Character.isSurrogate(it) }) return NicknameInputState.INVALID
 
-        return if (allowedRegex.matches(nickname)) NicknameInputState.VALID else NicknameInputState.INVALID
+        return if (allowedRegex.matches(nickname))
+            NicknameInputState.VALID
+        else
+            NicknameInputState.INVALID
     }
 
+    // 갤러리 열기
     private fun openGallery() {
         pickImageLauncher.launch(
             PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
         )
     }
 
+    // 카메라 열기
     private fun openCamera() {
         val uri = createCameraImageUri() ?: return
         cameraImageUri = uri
         takePictureLauncher.launch(uri)
     }
 
+    // 카메라 촬영용 임시 Uri 생성
     private fun createCameraImageUri(): Uri? {
         val dir = File(cacheDir, "camera")
         if (!dir.exists()) dir.mkdirs()
@@ -215,6 +297,28 @@ class OnbProfileActivity : AppCompatActivity() {
         )
     }
 
+    // 커스텀 토스트 표시
+    private fun showCustomToast(
+        message: String,
+        iconRes: Int = R.drawable.ic_check
+    ) {
+        val inflater = layoutInflater
+        val layout = inflater.inflate(R.layout.toast_custom, null)
+
+        val iconIv = layout.findViewById<ImageView>(R.id.toast_icon_iv)
+        val messageTv = layout.findViewById<TextView>(R.id.toast_message_tv)
+
+        iconIv.setImageResource(iconRes)
+        messageTv.text = message
+
+        Toast(this).apply {
+            duration = Toast.LENGTH_SHORT
+            view = layout
+            setGravity(Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL, 0, 120)
+        }.show()
+    }
+
+    // 닉네임 입력 상태
     private enum class NicknameInputState {
         EMPTY, INVALID, VALID
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileViewModel.kt
@@ -1,0 +1,115 @@
+package com.bookiibookii.bookiibookii.onboarding.profile
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bookiibookii.bookiibookii.data.api.RetrofitClient
+import com.bookiibookii.bookiibookii.data.api.S3Uploader
+import kotlinx.coroutines.launch
+
+class OnbProfileViewModel : ViewModel() {
+
+    // 닉네임 중복 검사 상태 관리
+    private val _nicknameState = MutableLiveData<NicknameCheckState>(NicknameCheckState.Idle)
+    val nicknameState: LiveData<NicknameCheckState> = _nicknameState
+
+    // 프로필 이미지 업로드 상태 관리
+    private val _imageUploadState =
+        MutableLiveData<ProfileImageUploadState>(ProfileImageUploadState.Idle)
+    val imageUploadState: LiveData<ProfileImageUploadState> = _imageUploadState
+
+    // 온보딩 저장 API에 전달할 S3 Key 보관용
+    private val _profileS3Key = MutableLiveData<String?>(null)
+    val profileS3Key: LiveData<String?> = _profileS3Key
+
+    // 닉네임 중복 검사 요청
+    fun checkNickname(nickname: String) {
+        viewModelScope.launch {
+            _nicknameState.value = NicknameCheckState.Loading
+
+            runCatching {
+                RetrofitClient.api().postNicknameValidation(nickname)
+            }.onSuccess { response ->
+                if (!response.isSuccessful) {
+                    _nicknameState.value =
+                        NicknameCheckState.Error("서버 오류가 발생했습니다. (${response.code()})")
+                    return@onSuccess
+                }
+
+                val body = response.body()
+                if (body?.isSuccess != true) {
+                    _nicknameState.value =
+                        NicknameCheckState.Error(body?.message ?: "요청에 실패했습니다.")
+                    return@onSuccess
+                }
+
+                val available = body.result?.isAvailable == true
+                _nicknameState.value = if (available) {
+                    NicknameCheckState.Available("사용 가능한 닉네임입니다.")
+                } else {
+                    NicknameCheckState.Duplicated("이미 존재하는 닉네임입니다.")
+                }
+
+            }.onFailure { e ->
+                _nicknameState.value =
+                    NicknameCheckState.Error(e.message ?: "네트워크 오류가 발생했습니다.")
+            }
+        }
+    }
+
+    // 프로필 이미지 업로드 (Presigned URL + S3 PUT)
+    fun uploadProfileImage(contentResolver: ContentResolver, uri: Uri) {
+        viewModelScope.launch {
+            _imageUploadState.value = ProfileImageUploadState.Loading
+
+            // TODO: 추후 로그 삭제
+            android.util.Log.d("IMG_UPLOAD", "🚀 uploadProfileImage start, uri=$uri")
+
+            runCatching {
+                // TODO: 추후 로그 삭제
+                android.util.Log.d("IMG_UPLOAD", "📡 request presigned-url")
+
+                val presignedRes = RetrofitClient.api().postPresignedUrl()
+                if (!presignedRes.isSuccessful) {
+                    error("Presigned URL 발급 실패 (HTTP ${presignedRes.code()})")
+                }
+
+                val body = presignedRes.body()
+                if (body?.isSuccess != true || body.result == null) {
+                    error(body?.message ?: "Presigned URL 발급 실패")
+                }
+
+                val s3Key = body.result.s3Key
+                val putUrl = body.result.presignedPutUrl
+
+                // TODO: 추후 로그 삭제
+                android.util.Log.d("IMG_UPLOAD", "🔑 s3Key=$s3Key")
+
+                // TODO: 추후 로그 삭제
+                android.util.Log.d("IMG_UPLOAD", "☁️ S3 PUT start")
+
+                S3Uploader.uploadImage(contentResolver, uri, putUrl).getOrThrow()
+
+                // TODO: 추후 로그 삭제
+                android.util.Log.d("IMG_UPLOAD", "✅ S3 PUT success")
+
+                s3Key
+            }.onSuccess { s3Key ->
+                // TODO: 추후 로그 삭제
+                android.util.Log.d("IMG_UPLOAD", "🎉 state=Success")
+
+                _profileS3Key.value = s3Key
+                _imageUploadState.value = ProfileImageUploadState.Success(s3Key)
+            }.onFailure { e ->
+                _imageUploadState.value =
+                    ProfileImageUploadState.Error(e.message ?: "이미지 업로드에 실패했습니다.")
+
+                // TODO: 추후 로그 삭제
+                android.util.Log.e("IMG_UPLOAD", "💥 state=Error", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/ProfileImageUploadState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/ProfileImageUploadState.kt
@@ -1,0 +1,8 @@
+package com.bookiibookii.bookiibookii.onboarding.profile
+
+sealed class ProfileImageUploadState {
+    data object Idle : ProfileImageUploadState()
+    data object Loading : ProfileImageUploadState()
+    data class Success(val s3Key: String) : ProfileImageUploadState()
+    data class Error(val message: String) : ProfileImageUploadState()
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStatusActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStatusActivity.kt
@@ -7,104 +7,80 @@ import android.view.View
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import com.bookiibookii.bookiibookii.MainActivity
 import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.data.api.RetrofitClient
+import com.bookiibookii.bookiibookii.data.model.OnboardingRequest
+import com.bookiibookii.bookiibookii.data.model.OnboardingTag
 import com.google.android.material.button.MaterialButton
+import kotlinx.coroutines.launch
+import androidx.core.content.edit
 
+// 온보딩 완료/로딩 상태를 표시하는 액티비티
 class OnbStatusActivity : AppCompatActivity() {
 
-    // 로딩/완료 상태에서 상단에 노출되는 주황색 안내 텍스트
+    // 상단/하단 텍스트 및 하단 버튼
     private lateinit var tvTopOrange: TextView
-
-    // 완료 상태에서 노출되는 검정색 타이틀 텍스트
     private lateinit var tvTopBlack: TextView
-
-    // 완료 상태에서 타이틀 아래에 노출되는 주황색 설명 텍스트
     private lateinit var tvBottomOrange: TextView
-
-    // include_onb_button.xml이 버튼 단일 레이아웃이므로 include 자체가 버튼
     private lateinit var btnFooter: MaterialButton
 
     // 현재 화면 상태 (로딩 / 완료)
     private var status: Status = Status.LOADING
 
-    // LOADING 상태에서 일정 시간 후 COMPLETE 상태로 전환하기 위한 Runnable
-    private val moveToCompleteRunnable = Runnable {
-        status = Status.COMPLETE
-        render(status)
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_onb_status)
 
-        // View 참조 바인딩
+        // 뷰 바인딩
         bindViews()
-
-        // 뒤로가기 및 버튼 클릭 등 이벤트 바인딩
+        // 클릭/뒤로가기 액션 바인딩
         bindActions()
 
-        // Intent로 전달된 상태 값이 있으면 사용, 없으면 기본값 LOADING
+        // 전달받은 상태 값 파싱 (기본값: LOADING)
         status = intent.getStringExtra(EXTRA_STATUS)
             ?.let { runCatching { Status.valueOf(it) }.getOrNull() }
             ?: Status.LOADING
 
-        // 현재 상태에 맞는 UI 렌더링
+        // 상태에 따른 UI 렌더링
         render(status)
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        // Activity 종료 시 예약된 자동 전환 Runnable 제거 (메모리 누수 방지)
-        tvTopOrange.removeCallbacks(moveToCompleteRunnable)
     }
 
+    // 뷰 초기화
     private fun bindViews() {
-        // 상태별로 보여줄 텍스트 뷰들 바인딩
         tvTopOrange = findViewById(R.id.tv_top_orange)
         tvTopBlack = findViewById(R.id.tv_top_black)
         tvBottomOrange = findViewById(R.id.tv_bottom_orange)
-
-        // include_onb_button의 id가 버튼 자체이므로 바로 버튼으로 캐스팅
         btnFooter = findViewById(R.id.include_footer_button)
     }
 
+    // 버튼 클릭 및 뒤로가기 처리
     private fun bindActions() {
-        // 뒤로가기 동작 커스텀
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                // 완료 상태에서는 온보딩 재진입을 막기 위해 앱 종료
-                if (status == Status.COMPLETE) {
-                    finishAffinity()
-                } else {
-                    // 로딩 중에는 단순히 현재 화면 종료
-                    finish()
-                }
+                // 완료 상태에서는 앱 전체 종료, 그 외에는 현재 화면 종료
+                if (status == Status.COMPLETE) finishAffinity()
+                else finish()
             }
         })
 
-        // 완료 화면에서 하단 버튼 클릭 시 메인 화면으로 이동
+        // 완료 버튼 클릭 시 온보딩 완료 처리 후 메인으로 이동
         btnFooter.setOnClickListener {
             setOnboardingDone()
-
-            // TODO: 온보딩까지 구현 후 삭제
-            Log.d("ONB_FLOW", "saved onboarding_done=true")
-
             val intent = Intent(this, MainActivity::class.java)
-            intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            intent.flags =
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             startActivity(intent)
             finish()
         }
     }
 
-    private fun setOnboardingDone() {
-        val prefs = getSharedPreferences("auth_prefs", MODE_PRIVATE)
-        prefs.edit()
-            .putBoolean("onboarding_done", true)
-            .apply()
-    }
-
-    // 현재 상태에 따라 로딩 화면 / 완료 화면 분기 처리
+    // 상태에 따른 분기 처리
     private fun render(status: Status) {
         when (status) {
             Status.LOADING -> renderLoading()
@@ -112,44 +88,113 @@ class OnbStatusActivity : AppCompatActivity() {
         }
     }
 
+    // 로딩 화면 UI 처리
     private fun renderLoading() {
-        // 로딩 상태 UI 노출
         tvTopOrange.visibility = View.VISIBLE
         tvTopBlack.visibility = View.GONE
         tvBottomOrange.visibility = View.GONE
         btnFooter.visibility = View.GONE
 
-        // strings.xml에 정의된 로딩 안내 문구 설정
         tvTopOrange.setText(R.string.onb_status_loading)
 
-        // 중복 예약 방지를 위해 기존 Runnable 제거 후 다시 예약
-        tvTopOrange.removeCallbacks(moveToCompleteRunnable)
-        tvTopOrange.postDelayed(moveToCompleteRunnable, 1800)
+        // 온보딩 API 요청
+        requestOnboarding()
     }
 
+    // 온보딩 데이터 서버 전송
+    private fun requestOnboarding() {
+        val name = intent.getStringExtra(EXTRA_NAME) ?: run {
+            // TODO: 추후 로그 삭제
+            Log.e("ONB_API", "name is null")
+            finish()
+            return
+        }
+
+        val s3Key = intent.getStringExtra(EXTRA_S3_KEY)
+
+        val genres = intent.getStringArrayListExtra(EXTRA_GENRES).orEmpty()
+        val methods = intent.getStringArrayListExtra(EXTRA_METHODS).orEmpty()
+        val speed = intent.getStringExtra(EXTRA_SPEED) ?: run {
+            // TODO: 추후 로그 삭제
+            Log.e("ONB_API", "speed is null")
+            finish()
+            return
+        }
+
+        // 서버 전송용 태그 리스트 구성
+        val tags = listOf(
+            OnboardingTag(type = "GENRE", value = genres),
+            OnboardingTag(type = "METHOD", value = methods),
+            OnboardingTag(type = "SPEED", value = listOf(speed))
+        )
+
+        val req = OnboardingRequest(
+            name = name,
+            tags = tags,
+            s3Key = s3Key
+        )
+
+        // TODO: 추후 로그 삭제
+        Log.d("ONB_API", "request=$req")
+        // TODO: 추후 로그 삭제
+        Log.d("ONB_API", "name=$name s3Key=$s3Key genres=$genres methods=$methods speed=$speed")
+
+        lifecycleScope.launch {
+            runCatching {
+                RetrofitClient.api().postOnboarding(req)
+            }.onSuccess { res ->
+                val body = res.body()
+
+                // TODO: 추후 로그 삭제
+                Log.d("ONB_API", "http=${res.code()} success=${res.isSuccessful} body=$body")
+
+                // 성공 시 완료 상태로 전환
+                if (res.isSuccessful && body?.isSuccess == true) {
+                    status = Status.COMPLETE
+                    render(status)
+                } else {
+                    // TODO: 추후 로그 삭제
+                    Log.e("ONB_API", "failed: http=${res.code()} msg=${body?.message}")
+                    finish()
+                }
+            }.onFailure { e ->
+                // TODO: 추후 로그 삭제
+                Log.e("ONB_API", "network error", e)
+                finish()
+            }
+        }
+    }
+
+    // 완료 화면 UI 처리
     private fun renderComplete() {
-        // 완료 상태 UI 노출
         tvTopOrange.visibility = View.GONE
         tvTopBlack.visibility = View.VISIBLE
         tvBottomOrange.visibility = View.VISIBLE
         btnFooter.visibility = View.VISIBLE
 
-        // 완료 상태 문구 설정
         tvTopBlack.setText(R.string.onb_status_complete_title)
         tvBottomOrange.setText(R.string.onb_status_complete_desc)
 
-        // 하단 버튼 활성화 및 문구 변경
         btnFooter.isEnabled = true
         btnFooter.setText(R.string.onb_status_complete_start)
     }
 
-    // 상태 구분 enum
-    enum class Status {
-        LOADING, COMPLETE
+    // 온보딩 완료 여부 로컬 저장
+    private fun setOnboardingDone() {
+        val prefs = getSharedPreferences("auth_prefs", MODE_PRIVATE)
+        prefs.edit { putBoolean("onboarding_done", true) }
     }
 
+    // 화면 상태 enum
+    enum class Status { LOADING, COMPLETE }
+
     companion object {
-        // 외부에서 상태를 전달받기 위한 Intent key
         const val EXTRA_STATUS = "extra_status"
+
+        const val EXTRA_NAME = "extra_name"
+        const val EXTRA_S3_KEY = "extra_s3_key"
+        const val EXTRA_GENRES = "extra_genres"
+        const val EXTRA_METHODS = "extra_methods"
+        const val EXTRA_SPEED = "extra_speed"
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStep1Fragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStep1Fragment.kt
@@ -27,16 +27,16 @@ class OnbStep1Fragment : Fragment(R.layout.fragment_onb_step1) {
 
     // 칩 표시 순서를 고정하기 위한 리스트
     private val chipItems = listOf(
-        ReadingPreference.ECONOMY,
-        ReadingPreference.SCIENCE_IT,
+        ReadingPreference.ECON_BIZ,
+        ReadingPreference.SCI_IT,
         ReadingPreference.NOVEL_GENRE,
         ReadingPreference.POEM_ESSAY,
         ReadingPreference.HOME_HOBBY,
         ReadingPreference.ART_CULTURE,
-        ReadingPreference.HUMANITIES_HISTORY,
-        ReadingPreference.SELF_HELP,
-        ReadingPreference.POLITICS_SOCIETY,
-        ReadingPreference.ETC
+        ReadingPreference.HUMAN_HISTORY,
+        ReadingPreference.SELF_DEV,
+        ReadingPreference.POL_SOC,
+        ReadingPreference.ESC
     )
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStep3Fragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStep3Fragment.kt
@@ -33,8 +33,8 @@ class OnbStep3Fragment : Fragment(R.layout.fragment_onb_step3) {
 
         // 독서 페이스 옵션을 화면에 동적으로 생성
         addChipOption(paceList, ReadingPace.FAST, topMarginDp = 0)
-        addChipOption(paceList, ReadingPace.WEEKLY, topMarginDp = 10)
-        addChipOption(paceList, ReadingPace.MONTHLY, topMarginDp = 10)
+        addChipOption(paceList, ReadingPace.NORMAL, topMarginDp = 10)
+        addChipOption(paceList, ReadingPace.SLOW, topMarginDp = 10)
         addTextOnlyOption(paceList, ReadingPace.UNKNOWN, topMarginDp = 10)
 
         // 상태 변화 감지 → 선택된 페이스에 따라 UI 자동 갱신

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.bookiibookii.bookiibookii.MainActivity
 import com.bookiibookii.bookiibookii.R
 import com.google.android.material.button.MaterialButton
+import androidx.core.content.edit
 
 class OnbStepActivity : AppCompatActivity() {
 
@@ -121,11 +122,34 @@ class OnbStepActivity : AppCompatActivity() {
 
     // 온보딩 완료 후 로딩 화면으로 이동
     private fun finishOnboarding() {
+        val state = vm.state.value ?: return
+
+        val genreValues = state.readingPreferences.map { it.serverValue }
+
+        // PHOTO/FOCUS 둘 다 serverValue가 CLEAN이니까 중복 제거 필요
+        val methodValues = state.recordMethods.map { it.serverValue }.distinct()
+
+        val speedValue = state.readingPace?.serverValue ?: return
+
+        // 프로필에서 넘어온 값 (onCreate에서 intent로 받아서 멤버로 들고있다고 가정)
+        val name = intent.getStringExtra(EXTRA_NAME) ?: return
+        val s3Key = intent.getStringExtra(EXTRA_S3_KEY) // null 가능
+
         startActivity(
             Intent(this, OnbStatusActivity::class.java)
                 .putExtra(OnbStatusActivity.EXTRA_STATUS, "LOADING")
+                .putExtra(OnbStatusActivity.EXTRA_NAME, name)
+                .putExtra(OnbStatusActivity.EXTRA_S3_KEY, s3Key)
+                .putStringArrayListExtra(OnbStatusActivity.EXTRA_GENRES, ArrayList(genreValues))
+                .putStringArrayListExtra(OnbStatusActivity.EXTRA_METHODS, ArrayList(methodValues))
+                .putExtra(OnbStatusActivity.EXTRA_SPEED, speedValue)
         )
         finish()
+    }
+
+    companion object {
+        const val EXTRA_NAME = "extra_name"
+        const val EXTRA_S3_KEY = "extra_s3_key"
     }
 
     // 현재 단계에 맞게 진행바 UI 갱신
@@ -149,9 +173,7 @@ class OnbStepActivity : AppCompatActivity() {
 
     private fun setOnboardingDone() {
         val prefs = getSharedPreferences("auth_prefs", MODE_PRIVATE)
-        prefs.edit()
-            .putBoolean("onboarding_done", true)
-            .apply()
+        prefs.edit { putBoolean("onboarding_done", true) }
     }
 
     // 현재 단계에서 "다음" 버튼을 활성화할 수 있는지 판단

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/data/ReadingPace.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/data/ReadingPace.kt
@@ -5,8 +5,8 @@ enum class ReadingPace(
     val displayName: String,
     val serverValue: String
 ) {
-    FAST("약 3일", "앉은 자리에서 뚝딱!", "3_7_DAYS"),
-    WEEKLY("약 1주", "매일매일 꾸준히", "7_14_DAYS"),
-    MONTHLY("약 1개월", "틈날 때마다 여유롭게", "14_30_DAYS"),
+    FAST("약 3일", "앉은 자리에서 뚝딱!", "FAST"),
+    NORMAL("약 1주", "매일매일 꾸준히", "NORMAL"),
+    SLOW("약 1개월", "틈날 때마다 여유롭게", "SLOW"),
     UNKNOWN("", "아직 내 속도를 모르겠어요", "UNKNOWN");
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/data/ReadingPreference.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/data/ReadingPreference.kt
@@ -4,14 +4,14 @@ enum class ReadingPreference(
     val displayName: String,
     val serverValue: String
 ) {
-    ECONOMY("경제/경영", "ECONOMY"),
-    SCIENCE_IT("과학/IT", "SCIENCE_IT"),
+    ECON_BIZ("경제/경영", "ECON_BIZ"),
+    SCI_IT("과학/IT", "SCI_IT"),
     NOVEL_GENRE("소설/장르", "NOVEL_GENRE"),
     POEM_ESSAY("시/에세이", "POEM_ESSAY"),
     HOME_HOBBY("가정/취미", "HOME_HOBBY"),
     ART_CULTURE("예술/문화", "ART_CULTURE"),
-    HUMANITIES_HISTORY("인문/역사", "HUMANITIES_HISTORY"),
-    SELF_HELP("자기계발", "SELF_HELP"),
-    POLITICS_SOCIETY("정치/사회", "POLITICS_SOCIETY"),
-    ETC("기타", "ETC");
+    HUMAN_HISTORY("인문/역사", "HUMAN_HISTORY"),
+    SELF_DEV("자기계발", "SELF_DEV"),
+    POL_SOC("정치/사회", "POL_SOC"),
+    ESC("기타", "ESC");
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/data/RecordMethod.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/data/RecordMethod.kt
@@ -16,21 +16,21 @@ enum class RecordMethod(
         tagLabel = "#메모환영",
         iconRes = R.drawable.ic_onb_record_pen
     ),
-    POST_IT(
+    POSTIT(
         titleResId = R.string.onb_step2_record_postit,
-        serverValue = "POST_IT",
+        serverValue = "POSTIT",
         tagLabel = "#포스트잇",
         iconRes = R.drawable.ic_onb_record_postit
     ),
     PHOTO(
         titleResId = R.string.onb_step2_record_photo,
-        serverValue = "PHOTO",
+        serverValue = "CLEAN",
         tagLabel = "#깔끔",
         iconRes = R.drawable.ic_onb_record_camera
     ),
     FOCUS(
         titleResId = R.string.onb_step2_record_focus,
-        serverValue = "FOCUS",
+        serverValue = "CLEAN",
         tagLabel = "#깔끔",
         iconRes = R.drawable.ic_onb_record_focus
     );

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,6 +10,7 @@
         android:id="@+id/fragmentContainer"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:layout_marginBottom="-15dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/bottomNav"
         app:layout_constraintStart_toStartOf="parent"
@@ -19,9 +20,11 @@
     <include
         android:id="@+id/bottomNav"
         layout="@layout/view_bottom_nav"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="14dp"
+        android:layout_width="match_parent"
+        android:layout_height="76dp"
+        android:layout_marginStart="15dp"
+        android:layout_marginEnd="15dp"
+        android:layout_marginBottom="5dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/toast_custom.xml
+++ b/app/src/main/res/layout/toast_custom.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/bg_input_round_20dp_white_and_200"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:paddingHorizontal="20dp"
     android:paddingVertical="12dp"
-    android:padding="16dp">
+    android:padding="16dp"
+    android:layout_marginStart="20dp"
+    android:layout_marginEnd="20dp" >
 
     <ImageView
         android:id="@+id/toast_icon_iv"

--- a/app/src/main/res/layout/view_bottom_nav.xml
+++ b/app/src/main/res/layout/view_bottom_nav.xml
@@ -1,155 +1,142 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/bottomNavRoot"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingStart="20dp"
-    android:paddingEnd="20dp"
-    android:paddingTop="14dp"
-    android:paddingBottom="14dp">
+    android:layout_height="76dp"
+    android:baselineAligned="false"
+    android:orientation="horizontal"
+    android:background="@drawable/bg_round_20dp_white_stroke_1dp_gray200"
+    android:paddingStart="18dp"
+    android:paddingEnd="18dp"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent"
+    android:gravity="center">
 
-    <!-- 둥근 흰색 바(배경) -->
+    <!-- item 1: 홈 -->
     <LinearLayout
-        android:id="@+id/bottomNavContainer"
+        android:id="@+id/itemHome"
         android:layout_width="0dp"
-        android:layout_height="72dp"
-        android:orientation="horizontal"
-        android:background="@drawable/bg_bottom_nav"
-        android:elevation="8dp"
-        android:paddingStart="18dp"
-        android:paddingEnd="18dp"
-        android:gravity="center"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
 
-        <!-- item 1: 홈 -->
-        <LinearLayout
-            android:id="@+id/itemHome"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center">
+        <ImageView
+            android:id="@+id/ivHome"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_home_unselected" />
 
-            <ImageView
-                android:id="@+id/ivHome"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_home_unselected" />
-
-            <TextView
-                android:id="@+id/tvHome"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:text="홈"
-                android:textSize="11sp"
-                android:textColor="@color/grey_400" />
-        </LinearLayout>
-
-        <!-- item 2: 그룹 -->
-        <LinearLayout
-            android:id="@+id/itemGroup"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center">
-
-            <ImageView
-                android:id="@+id/ivGroup"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_group_unselected" />
-
-            <TextView
-                android:id="@+id/tvGroup"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:text="그룹"
-                android:textSize="11sp"
-                android:textColor="@color/grey_400" />
-        </LinearLayout>
-
-        <!-- item 3: 트래커 -->
-        <LinearLayout
-            android:id="@+id/itemTracker"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center">
-
-            <ImageView
-                android:id="@+id/ivTracker"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_tracker_unselected" />
-
-            <TextView
-                android:id="@+id/tvTracker"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:text="트래커"
-                android:textSize="11sp"
-                android:textColor="@color/grey_400" />
-        </LinearLayout>
-
-        <!-- item 4: 서재 -->
-        <LinearLayout
-            android:id="@+id/itemLibrary"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center">
-
-            <ImageView
-                android:id="@+id/ivLibrary"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_library_unselected" />
-
-            <TextView
-                android:id="@+id/tvLibrary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:text="서재"
-                android:textSize="11sp"
-                android:textColor="@color/grey_400" />
-        </LinearLayout>
-
-        <!-- item 5: 마이페이지 -->
-        <LinearLayout
-            android:id="@+id/itemMy"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:gravity="center">
-
-            <ImageView
-                android:id="@+id/ivMy"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:src="@drawable/ic_mypage_unselected" />
-
-            <TextView
-                android:id="@+id/tvMy"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="6dp"
-                android:text="마이페이지"
-                android:textSize="11sp"
-                android:textColor="@color/grey_400" />
-        </LinearLayout>
-
+        <TextView
+            android:id="@+id/tvHome"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="홈"
+            android:textSize="11sp"
+            android:textColor="@color/grey_400" />
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <!-- item 2: 그룹 -->
+    <LinearLayout
+        android:id="@+id/itemGroup"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <ImageView
+            android:id="@+id/ivGroup"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_group_unselected" />
+
+        <TextView
+            android:id="@+id/tvGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="그룹"
+            android:textSize="11sp"
+            android:textColor="@color/grey_400" />
+    </LinearLayout>
+
+    <!-- item 3: 트래커 -->
+    <LinearLayout
+        android:id="@+id/itemTracker"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <ImageView
+            android:id="@+id/ivTracker"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_tracker_unselected" />
+
+        <TextView
+            android:id="@+id/tvTracker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="트래커"
+            android:textSize="11sp"
+            android:textColor="@color/grey_400" />
+    </LinearLayout>
+
+    <!-- item 4: 서재 -->
+    <LinearLayout
+        android:id="@+id/itemLibrary"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <ImageView
+            android:id="@+id/ivLibrary"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_library_unselected" />
+
+        <TextView
+            android:id="@+id/tvLibrary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="서재"
+            android:textSize="11sp"
+            android:textColor="@color/grey_400" />
+    </LinearLayout>
+
+    <!-- item 5: 마이페이지 -->
+    <LinearLayout
+        android:id="@+id/itemMy"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <ImageView
+            android:id="@+id/ivMy"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_mypage_unselected" />
+
+        <TextView
+            android:id="@+id/tvMy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="마이페이지"
+            android:textSize="11sp"
+            android:textColor="@color/grey_400" />
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
# 📌 Pull Request Title
ui: 바텀 네비게이션 레이아웃 구조 및 여백 개선

---

# ✨ 작업 내용 (What)
- 바텀 네비게이션 그림자 제거 및 배경 레이아웃 수정
- 커스텀 바텀 네비게이션 레이아웃을 LinearLayout 단일 구조로 단순화
- 불필요한 ConstraintLayout 제거로 레이아웃 뎁스 감소
- include 사용 시 layout_width="match_parent"로 수정하여 폭 계산 안정화
- 바텀 네비 여백(margin) 관리 위치를 명확히 분리하여 중복 적용 이슈 제거

---

# 🧪 테스트 방법 (How to Test)
1. 앱 실행 후 홈 화면 진입
2. 하단 바텀 네비게이션이 화면 하단에 정상적으로 노출되는지 확인

---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #117
