### PR TITLE
feat: 닉네임 입력 제한 및 검증 로직 개선 (#128)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/UserModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/UserModel.kt
@@ -1,6 +1,6 @@
 package com.bookiibookii.bookiibookii.data.model
 
-// 1) 닉네임 중복 확인
+// 1) 닉네임 중복 + 금칙어 포함 여부 확인
 data class NicknameValidationResponse(
     val isSuccess: Boolean,
     val code: String,
@@ -9,7 +9,9 @@ data class NicknameValidationResponse(
 )
 
 data class NicknameValidationResult(
-    val isAvailable: Boolean
+    val isAvailable: Boolean,
+    val code: String,
+    val message: String
 )
 
 // 2) Presigned URL

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileActivity.kt
@@ -15,6 +15,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.core.graphics.toColorInt
 import androidx.core.widget.addTextChangedListener
+import android.text.InputFilter
+import android.text.Spannable
+import android.view.inputmethod.BaseInputConnection
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.databinding.ActivityOnbProfileBinding
 import com.bookiibookii.bookiibookii.onboarding.steps.OnbStepActivity
@@ -35,18 +38,13 @@ class OnbProfileActivity : AppCompatActivity() {
     // 업로드 완료된 프로필 이미지 S3 Key
     private var uploadedS3Key: String? = null
 
-    // 서비스 금칙어 (임시)
-    // TODO: API 연동 후 삭제
-    private val bannedWords = listOf(
-        "관리자",
-        "admin",
-        "운영자",
-        "bookii",
-        "시발",
-        "병신",
-        "fuck",
-        "shit"
-    )
+    // 문자 1개 허용 여부(필터에서 사용)
+    private val nicknameAllowedCharRegex =
+        Regex("[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z0-9._\\-_/()\\[\\]:!?]")
+
+    // 전체 문자열 허용 여부(최종 검증에서 사용)
+    private val nicknameAllowedRegex =
+        Regex("^[가-힣A-Za-z0-9._\\-_/()\\[\\]:!?]+$")
 
     // 갤러리 이미지 선택 런처 (권한 불필요)
     private val pickImageLauncher =
@@ -78,6 +76,7 @@ class OnbProfileActivity : AppCompatActivity() {
         binding = ActivityOnbProfileBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        setupNicknameFilters()
         initView()
         initListeners()
         observeViewModel()
@@ -113,12 +112,6 @@ class OnbProfileActivity : AppCompatActivity() {
             // 형식 검증
             if (validateNicknameInput(nickname) != NicknameInputState.VALID) {
                 showError("허용되지 않은 문자가 포함되어 있습니다.")
-                return@setOnClickListener
-            }
-
-            // 금칙어 검증
-            if (containsBannedWord(nickname)) {
-                showError("금칙어가 포함되어 있습니다.")
                 return@setOnClickListener
             }
 
@@ -246,28 +239,37 @@ class OnbProfileActivity : AppCompatActivity() {
         binding.includeFooterButton.btnFooter.isEnabled = false
     }
 
-    // 금칙어 포함 여부 확인
-    private fun containsBannedWord(nickname: String): Boolean {
-        val lower = nickname.lowercase()
-        return bannedWords.any { banned -> lower.contains(banned.lowercase()) }
-    }
-
     // 닉네임 형식 검증
     private fun validateNicknameInput(nickname: String): NicknameInputState {
         if (nickname.isBlank()) return NicknameInputState.EMPTY
         if (nickname.length > 10) return NicknameInputState.INVALID
-        if (nickname.any { it.isWhitespace() }) return NicknameInputState.INVALID
+        if (nickname.any { it.isWhitespace() || Character.isSurrogate(it) }) return NicknameInputState.INVALID
 
-        // 허용 문자 정규식
-        val allowedRegex = Regex("^[가-힣A-Za-z0-9._\\-\\/\\(\\)\\[\\]:!?]+$")
-
-        // 이모지(서로게이트 문자) 차단
-        if (nickname.any { Character.isSurrogate(it) }) return NicknameInputState.INVALID
-
-        return if (allowedRegex.matches(nickname))
+        return if (nicknameAllowedRegex.matches(nickname))
             NicknameInputState.VALID
         else
             NicknameInputState.INVALID
+    }
+
+    // 닉네임 입력 단계에서 허용되지 않은 문자/공백/이모지 입력 방지 + 10자 제한
+    private fun setupNicknameFilters() {
+        val lengthFilter = InputFilter.LengthFilter(10)
+
+        val blockInvalidInputFilter = InputFilter { source, start, end, _, _, _ ->
+            if (source.isEmpty()) return@InputFilter null // 삭제 허용
+
+            for (i in start until end) {
+                val ch = source[i]
+
+                if (ch.isWhitespace()) return@InputFilter ""
+                if (Character.isSurrogate(ch)) return@InputFilter ""
+                if (!nicknameAllowedCharRegex.matches(ch.toString())) return@InputFilter ""
+            }
+
+            null
+        }
+
+        binding.etNickname.filters = arrayOf(lengthFilter, blockInvalidInputFilter)
     }
 
     // 갤러리 열기

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileViewModel.kt
@@ -25,7 +25,7 @@ class OnbProfileViewModel : ViewModel() {
     private val _profileS3Key = MutableLiveData<String?>(null)
     val profileS3Key: LiveData<String?> = _profileS3Key
 
-    // 닉네임 중복 검사 요청
+    // 닉네임 중복/금칙어 검사 요청
     fun checkNickname(nickname: String) {
         viewModelScope.launch {
             _nicknameState.value = NicknameCheckState.Loading
@@ -40,17 +40,22 @@ class OnbProfileViewModel : ViewModel() {
                 }
 
                 val body = response.body()
-                if (body?.isSuccess != true) {
+                if (body?.isSuccess != true || body.result == null) {
                     _nicknameState.value =
                         NicknameCheckState.Error(body?.message ?: "요청에 실패했습니다.")
                     return@onSuccess
                 }
 
-                val available = body.result?.isAvailable == true
-                _nicknameState.value = if (available) {
-                    NicknameCheckState.Available("사용 가능한 닉네임입니다.")
-                } else {
-                    NicknameCheckState.Duplicated("이미 존재하는 닉네임입니다.")
+                val result = body.result
+                val msg = result.message.ifBlank { "요청에 실패했습니다." }
+
+                _nicknameState.value = when (result.code) {
+                    "SUCCESS" -> NicknameCheckState.Available(msg)
+
+                    // 사용 불가: 중복/금칙어
+                    "DUPLICATE", "BAD_WORD" -> NicknameCheckState.Duplicated(msg)
+
+                    else -> NicknameCheckState.Error(msg)
                 }
 
             }.onFailure { e ->


### PR DESCRIPTION
# 📌 Pull Request Title
feat: 닉네임 입력 제한 및 검증 로직 개선

---

# ✨ 작업 내용 (What)
- 닉네임 검증 API 응답 코드 분기 처리
   - SUCCESS / DUPLICATE / BAD_WORD 케이스에 따라 상태 분기
   - 서버에서 내려주는 message를 검증 결과 UI에 그대로 반영
- 닉네임 입력 필드 실시간 입력 제한 적용
   - 최대 10자 초과 입력 방지
   - 공백 입력 차단
   - 이모지 입력 차단
   - 허용되지 않은 특수문자 입력 차단
- 한글 IME 입력 환경에서 조합 중 입력이 정상 동작하도록 필터 로직 개선
- 입력 필터 + 최종 형식 검증 로직 분리로 안정성 강화

---

# 🧪 테스트 방법 (How to Test)
1. 온보딩 프로필 화면 진입
2. 닉네임 입력 테스트
   - 10자 초과 입력 시 추가 입력 불가 확인
   - 공백 / 이모지 / 허용되지 않은 특수문자 입력 시 입력 차단 확인
   - 한글 입력 시 글자 깨짐 없이 정상 입력되는지 확인
3. 닉네임 중복 확인 버튼 클릭
   - 사용 가능한 닉네임 → 성공 UI 및 다음 버튼 활성화
   - 중복 닉네임 → 에러 메시지 노출 확인
   - 금칙어 포함 닉네임 → 에러 메시지 노출 확인

---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #128
