### PR TITLE
feat: 토큰 자동 재발급 및 공통 에러 라우팅 구조 적용

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/common/ComErrorActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/common/ComErrorActivity.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.data.api.AuthInterceptor
 import com.google.android.material.button.MaterialButton
 
 class ComErrorActivity : AppCompatActivity() {
@@ -100,12 +101,15 @@ class ComErrorActivity : AppCompatActivity() {
     private fun bindActions(type: Int) {
         // 다시 시도 (10/11에서만 노출)
         btnTop.setOnClickListener {
+            AuthInterceptor.unlockRouting()
+            ComRetryBus.emitRetry()
             setResult(RESULT_RETRY)
             finish()
         }
 
         // 하단 버튼: 이전으로(10/11) or 메인으로(12/13)
         btnBottom.setOnClickListener {
+            AuthInterceptor.unlockRouting()
             when (type) {
                 TYPE_NO_PERMISSION, TYPE_GROUP_DELETED -> setResult(RESULT_GO_MAIN)
                 else -> setResult(Activity.RESULT_CANCELED)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/common/ComRetryBus.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/common/ComRetryBus.kt
@@ -1,0 +1,14 @@
+package com.bookiibookii.bookiibookii.common
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+object ComRetryBus {
+
+    private val _retryFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val retryFlow: SharedFlow<Unit> = _retryFlow
+
+    fun emitRetry() {
+        _retryFlow.tryEmit(Unit)
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/ApiService.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/ApiService.kt
@@ -49,13 +49,10 @@ import com.bookiibookii.bookiibookii.data.model.WithdrawResponse
 import com.bookiibookii.bookiibookii.onboarding.login.LoginActivity
 import okhttp3.RequestBody
 import com.bookiibookii.bookiibookii.trkData.api.TrkApi
-import com.bookiibookii.bookiibookii.trkData.dto.ApiResponse
-import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -104,10 +101,10 @@ interface ApiService: TrkApi {
     @POST("api/report")
     suspend fun postReport(@Body request: ReportRequest): Response<ReportCreateResponse>
 
-    @POST("api/auth/refresh")
-    fun refreshToken(
+    @POST("/api/auth/refresh")
+    suspend fun postRefresh(
         @Body request: TokenRefreshRequest
-    ): retrofit2.Call<TokenRefreshResponse>
+    ): Response<TokenRefreshResponse>
 
     @GET("api/report/groups/my")
     suspend fun getMyGroups(): Response<MyGroupResponse>

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/AuthInterceptor.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/AuthInterceptor.kt
@@ -1,0 +1,186 @@
+package com.bookiibookii.bookiibookii.data.api
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.edit
+import com.bookiibookii.bookiibookii.common.ComErrorActivity
+import com.bookiibookii.bookiibookii.data.model.TokenRefreshRequest
+import com.bookiibookii.bookiibookii.onboarding.login.LoginActivity
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+
+class AuthInterceptor(private val context: Context) : Interceptor {
+
+    private enum class RefreshOutcome { SUCCESS, INVALID_TOKEN, NETWORK_ERROR, SYSTEM_ERROR }
+
+    companion object {
+        private val isRouting = AtomicBoolean(false)
+
+        fun unlockRouting() {
+            isRouting.set(false)
+        }
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val originalRequest = chain.request()
+
+        val appContext = context.applicationContext
+        val prefs = appContext.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+
+        val accessToken = prefs.getString("access_token", null)
+
+        val newRequest = if (accessToken.isNullOrEmpty()) {
+            originalRequest
+        } else {
+            originalRequest.newBuilder()
+                .header("Authorization", "Bearer $accessToken")
+                .build()
+        }
+
+        // proceed 자체가 네트워크 예외로 터질 수 있음
+        val response = try {
+            chain.proceed(newRequest)
+        } catch (e: IOException) {
+            routeComError(appContext, ComErrorActivity.TYPE_NETWORK_ERROR)
+            throw e
+        }
+
+        val url = newRequest.url.toString()
+        val method = newRequest.method
+
+        if (response.isSuccessful) {
+            Log.i("API_SUCCESS", "✅ [${response.code}] $method $url")
+            return response
+        } else {
+            Log.e("API_FAILURE", "❌ [${response.code}] $method $url")
+        }
+
+        if (response.code == 401) {
+
+            if (url.contains("/api/auth/refresh")) {
+                response.close()
+                routeLogout(appContext)
+                return response
+            }
+
+            val refreshToken = prefs.getString("refresh_token", null)
+            if (refreshToken.isNullOrEmpty()) {
+                response.close()
+                routeLogout(appContext)
+                return response
+            }
+
+            response.close()
+
+            val outcome = runBlocking {
+                try {
+                    val refreshRes = RetrofitClient.apiNoAuth().postRefresh(
+                        TokenRefreshRequest(refreshToken)
+                    )
+
+                    if (refreshRes.isSuccessful && refreshRes.body()?.isSuccess == true) {
+                        val result = refreshRes.body()?.result
+                            ?: return@runBlocking RefreshOutcome.SYSTEM_ERROR
+
+                        // TODO: 추후 로그 삭제 (refresh 성공 확인용)
+                        Log.d("TOKEN_REFRESH", "새 AccessToken 발급 성공")
+
+                        prefs.edit {
+                            putString("access_token", result.accessToken)
+                            putString("refresh_token", result.refreshToken)
+                            putInt("user_id", result.userId)
+                        }
+
+                        return@runBlocking RefreshOutcome.SUCCESS
+                    }
+
+                    val code = refreshRes.code()
+                    return@runBlocking when {
+                        code == 400 || code == 401 -> RefreshOutcome.INVALID_TOKEN
+                        code >= 500 -> RefreshOutcome.SYSTEM_ERROR
+                        else -> RefreshOutcome.SYSTEM_ERROR
+                    }
+
+                } catch (e: SocketTimeoutException) {
+                    RefreshOutcome.NETWORK_ERROR
+                } catch (e: IOException) {
+                    RefreshOutcome.NETWORK_ERROR
+                } catch (e: Exception) {
+                    RefreshOutcome.SYSTEM_ERROR
+                }
+            }
+
+            when (outcome) {
+                RefreshOutcome.SUCCESS -> {
+                    val newAccessToken = prefs.getString("access_token", null)
+
+                    val retryRequest = if (newAccessToken.isNullOrEmpty()) {
+                        originalRequest
+                    } else {
+                        originalRequest.newBuilder()
+                            .header("Authorization", "Bearer $newAccessToken")
+                            .build()
+                    }
+
+                    return chain.proceed(retryRequest)
+                }
+
+                RefreshOutcome.INVALID_TOKEN -> {
+                    routeLogout(appContext)
+                    return response
+                }
+
+                RefreshOutcome.NETWORK_ERROR -> {
+                    routeComError(appContext, ComErrorActivity.TYPE_NETWORK_ERROR)
+                    return response
+                }
+
+                RefreshOutcome.SYSTEM_ERROR -> {
+                    routeComError(appContext, ComErrorActivity.TYPE_SYSTEM_ERROR)
+                    return response
+                }
+            }
+        }
+
+        if (response.code >= 500) {
+            routeComError(appContext, ComErrorActivity.TYPE_SYSTEM_ERROR)
+            return response
+        }
+
+        return response
+    }
+
+    private fun routeLogout(context: Context) {
+        if (!isRouting.compareAndSet(false, true)) return
+
+        val prefs = context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
+        prefs.edit { clear() }
+
+        val intent = Intent(context, LoginActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            context.startActivity(intent)
+            // 여기서는 unlock 하지 않음 (LoginActivity에서 풀 것)
+        }
+    }
+
+    private fun routeComError(context: Context, type: Int) {
+        if (!isRouting.compareAndSet(false, true)) return
+
+        val intent = ComErrorActivity.newIntent(context, type).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            context.startActivity(intent)
+            // 여기서는 unlock 하지 않음 (ComErrorActivity에서 풀 것)
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/RetrofitClient.kt
@@ -1,144 +1,29 @@
 package com.bookiibookii.bookiibookii.data.api
 
 import android.content.Context
-import android.content.Intent
-import android.util.Log
-import com.bookiibookii.bookiibookii.data.model.TokenRefreshRequest
-import com.bookiibookii.bookiibookii.onboarding.login.LoginActivity
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
-// 인터셉터: 로그인 직후에도 바로 토큰을 인식 가능
-class AuthInterceptor(private val context: Context) : Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
-        val originalRequest = chain.request()
-
-        // 수정 포인트: 앱 전체 컨텍스트 사용 (안전성 확보)
-        val appContext = context.applicationContext
-        val prefs = appContext.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
-        val accessToken = prefs.getString("access_token", null)
-
-        val newRequest = if (accessToken.isNullOrEmpty()) {
-            originalRequest
-        } else {
-            originalRequest.newBuilder()
-                .addHeader("Authorization", "Bearer $accessToken")
-                .build()
-        }
-
-        val response = chain.proceed(newRequest)
-
-        // 성공/실패 로그 출력 로직 ★★★
-        val url = newRequest.url.toString()
-        val method = newRequest.method
-
-        if (response.isSuccessful) {
-            // 200번대 (성공)
-            Log.i("API_SUCCESS", "✅ [${response.code}] $method $url")
-        } else {
-            // 400, 500번대 (실패)
-            Log.e("API_FAILURE", "❌ [${response.code}] $method $url")
-        }
-
-// AuthInterceptor.kt 내부 수정
-
-        if (response.code == 401 || response.code == 500) {
-            if (url.contains("api/auth/refresh")) {
-                response.close()
-                performLogout(appContext)
-                return response
-            }
-
-            Log.d("DEBUG_TOKEN", "⚠️ 401 발생! 리프레시 시도 시작")
-
-            // 1. 저장된 리프레시 토큰 확인
-            val refreshToken = prefs.getString("refresh_token", null)
-            Log.d("DEBUG_TOKEN", "👉 저장된 리프레시 토큰 값: $refreshToken")
-
-            if (!refreshToken.isNullOrEmpty()) {
-                response.close() // 기존 응답 닫기
-
-                try {
-                    // 2. 서버로 갱신 요청 전송
-                    Log.d("DEBUG_TOKEN", "👉 리프레시 API 호출 시도...")
-                    val call = RetrofitClient.api().refreshToken(TokenRefreshRequest(refreshToken))
-                    val refreshResponse = call.execute() // 동기 호출
-
-                    // 3. 결과 확인
-                    Log.d("DEBUG_TOKEN", "👉 리프레시 API 응답 코드: ${refreshResponse.code()}")
-
-                    if (refreshResponse.isSuccessful && refreshResponse.body()?.isSuccess == true) {
-                        val newTokens = refreshResponse.body()!!.result
-                        if (newTokens != null) {
-                            Log.i("DEBUG_TOKEN", "✅ 갱신 성공! 새 토큰으로 교체")
-
-                            prefs.edit().apply {
-                                putString("access_token", newTokens.accessToken)
-                                putString("refresh_token", newTokens.refreshToken)
-                                putInt("user_id", newTokens.userId)
-                                apply()
-                            }
-
-                            val newRequest = originalRequest.newBuilder()
-                                .removeHeader("Authorization")
-                                .addHeader("Authorization", "Bearer ${newTokens.accessToken}")
-                                .build()
-
-                            return chain.proceed(newRequest)
-                        } else {
-                            Log.e("DEBUG_TOKEN", "❌ 성공은 했으나 result가 null임")
-                        }
-                    } else {
-                        // 여기가 중요합니다! 왜 실패했는지 서버 에러 메시지를 까봅니다.
-                        val errorBody = refreshResponse.errorBody()?.string()
-                        Log.e("DEBUG_TOKEN", "❌ 리프레시 실패. 이유: $errorBody")
-                    }
-
-                } catch (e: Exception) {
-                    Log.e("DEBUG_TOKEN", "❌ 네트워크/코드 에러: ${e.message}")
-                    e.printStackTrace()
-                }
-            } else {
-                Log.e("DEBUG_TOKEN", "❌ 저장소에 리프레시 토큰이 없음 (null)")
-            }
-
-            // 위에서 return 못 하고 여기까지 왔으면 실패한 것임
-            Log.e("AuthInterceptor", "🚫 토큰 갱신 최종 실패. 강제 로그아웃")
-            performLogout(appContext)
-        }
-        return response
-    }
-    private fun performLogout(context: Context) {
-        val prefs = context.getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
-        prefs.edit().clear().apply()
-
-        val intent = Intent(context, LoginActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        context.startActivity(intent)
-    }
-}
-
 object RetrofitClient {
     private const val BASE_URL = "https://bookii.gyeonseo.com/"
 
     @Volatile private var apiService: ApiService? = null
+    @Volatile private var apiServiceNoAuth: ApiService? = null
 
     fun init(context: Context) {
-        if (apiService != null) return
+        if (apiService != null && apiServiceNoAuth != null) return
 
         synchronized(this) {
-            if (apiService != null) return
+            if (apiService != null && apiServiceNoAuth != null) return
 
             val loggingInterceptor = HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.BODY
             }
 
-            val client = OkHttpClient.Builder()
+            val authedClient = OkHttpClient.Builder()
                 .addInterceptor(loggingInterceptor)
                 .addInterceptor(AuthInterceptor(context.applicationContext))
                 .connectTimeout(30, TimeUnit.SECONDS)
@@ -147,15 +32,31 @@ object RetrofitClient {
 
             val retrofit = Retrofit.Builder()
                 .baseUrl(BASE_URL)
-                .client(client)
+                .client(authedClient)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
 
             apiService = retrofit.create(ApiService::class.java)
+
+            val noAuthClient = OkHttpClient.Builder()
+                .addInterceptor(loggingInterceptor)
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build()
+
+            val retrofitNoAuth = Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(noAuthClient)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+
+            apiServiceNoAuth = retrofitNoAuth.create(ApiService::class.java)
         }
     }
 
     fun api(): ApiService =
         apiService ?: error("RetrofitClient.init(context) 먼저 호출해야 함")
 
+    fun apiNoAuth(): ApiService =
+        apiServiceNoAuth ?: error("RetrofitClient.init(context) 먼저 호출해야 함")
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/AuthModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/AuthModel.kt
@@ -58,13 +58,18 @@ data class WithdrawResponse(
 )
 
 data class TokenRefreshRequest(
-    @SerializedName("refreshToken")
     val refreshToken: String
+)
+
+data class TokenRefreshResult(
+    val accessToken: String,
+    val refreshToken: String,
+    val userId: Int
 )
 
 data class TokenRefreshResponse(
     val isSuccess: Boolean,
     val code: String,
     val message: String,
-    val result: LoginResult?
+    val result: TokenRefreshResult?
 )

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/notification/ui/NotificationKeywordFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/notification/ui/NotificationKeywordFragment.kt
@@ -3,7 +3,6 @@ package com.bookiibookii.bookiibookii.home.notification.ui
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -12,7 +11,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bookiibookii.bookiibookii.R
-import com.bookiibookii.bookiibookii.common.ComErrorActivity
+import com.bookiibookii.bookiibookii.common.ComRetryBus
 import com.bookiibookii.bookiibookii.data.api.RetrofitClient
 import com.bookiibookii.bookiibookii.data.model.NotificationCategory
 import com.bookiibookii.bookiibookii.data.model.NotificationItemDto
@@ -20,6 +19,7 @@ import com.bookiibookii.bookiibookii.home.notification.adapter.SystemAdapter
 import com.bookiibookii.bookiibookii.home.notification.data.NotificationRepository
 import com.bookiibookii.bookiibookii.home.notification.model.NotificationItem
 import com.bookiibookii.bookiibookii.home.notification.model.NotificationType
+import com.bookiibookii.bookiibookii.home.notification.util.NotificationPayloadParser
 import com.bookiibookii.bookiibookii.home.notification.util.TimeAgoFormatter
 import com.bookiibookii.bookiibookii.home.notification.vm.NotificationViewModel
 import com.bookiibookii.bookiibookii.home.notification.vm.NotificationViewModelFactory
@@ -33,13 +33,6 @@ class HomKeywordNotiFragment : Fragment(R.layout.fragment_notification_keyword) 
         }
         handleKeywordNotificationClick(item.notification)
     }
-
-    private val errorLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == ComErrorActivity.RESULT_RETRY) {
-                viewModel.loadFirstPage()
-            }
-        }
 
     private val viewModel: NotificationViewModel by viewModels {
         val api = RetrofitClient.api()
@@ -71,6 +64,14 @@ class HomKeywordNotiFragment : Fragment(R.layout.fragment_notification_keyword) 
             }
         })
 
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                ComRetryBus.retryFlow.collect {
+                    viewModel.loadFirstPage()
+                }
+            }
+        }
+
         // 첫 로딩
         viewModel.loadFirstPage()
 
@@ -80,12 +81,6 @@ class HomKeywordNotiFragment : Fragment(R.layout.fragment_notification_keyword) 
 
                     val uiItems = s.items.map { it.toUiItem() }
                     bind(uiItems, rv, empty)
-
-                    if (s.errorType != null) {
-                        errorLauncher.launch(
-                            ComErrorActivity.newIntent(requireContext(), s.errorType)
-                        )
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/notification/ui/NotificationSystemFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/notification/ui/NotificationSystemFragment.kt
@@ -3,7 +3,6 @@ package com.bookiibookii.bookiibookii.home.notification.ui
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -12,7 +11,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bookiibookii.bookiibookii.R
-import com.bookiibookii.bookiibookii.common.ComErrorActivity
+import com.bookiibookii.bookiibookii.common.ComRetryBus
 import com.bookiibookii.bookiibookii.data.api.RetrofitClient
 import com.bookiibookii.bookiibookii.data.model.NotificationCategory
 import com.bookiibookii.bookiibookii.data.model.NotificationItemDto
@@ -20,6 +19,7 @@ import com.bookiibookii.bookiibookii.home.notification.adapter.SystemAdapter
 import com.bookiibookii.bookiibookii.home.notification.data.NotificationRepository
 import com.bookiibookii.bookiibookii.home.notification.model.NotificationItem
 import com.bookiibookii.bookiibookii.home.notification.model.NotificationType
+import com.bookiibookii.bookiibookii.home.notification.util.NotificationPayloadParser
 import com.bookiibookii.bookiibookii.home.notification.util.TimeAgoFormatter
 import com.bookiibookii.bookiibookii.home.notification.vm.NotificationViewModel
 import com.bookiibookii.bookiibookii.home.notification.vm.NotificationViewModelFactory
@@ -33,13 +33,6 @@ class NotificationSystemFragment : Fragment(R.layout.fragment_notification_syste
         }
         handleNotificationClick(item.notification)
     }
-
-    private val errorLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if (result.resultCode == ComErrorActivity.RESULT_RETRY) {
-                viewModel.loadFirstPage()
-            }
-        }
 
     private val viewModel: NotificationViewModel by viewModels {
         val api = RetrofitClient.api()
@@ -75,6 +68,16 @@ class NotificationSystemFragment : Fragment(R.layout.fragment_notification_syste
             }
         })
 
+        // retry 이벤트 받으면 첫 페이지 다시 로드
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                ComRetryBus.retryFlow.collect {
+                    viewModel.loadFirstPage()
+                }
+            }
+        }
+
+
         // 첫 로딩
         viewModel.loadFirstPage()
 
@@ -85,12 +88,6 @@ class NotificationSystemFragment : Fragment(R.layout.fragment_notification_syste
 
                     val uiItems = s.items.map { it.toUiItem() }
                     bind(uiItems, rv, empty)
-
-                    if (s.errorType != null) {
-                        errorLauncher.launch(
-                            ComErrorActivity.newIntent(requireContext(), s.errorType)
-                        )
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/notification/util/NotificationPayloadParser.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/notification/util/NotificationPayloadParser.kt
@@ -1,4 +1,4 @@
-package com.bookiibookii.bookiibookii.home.notification.ui
+package com.bookiibookii.bookiibookii.home.notification.util
 
 import com.bookiibookii.bookiibookii.data.model.NotificationItemDto
 import org.json.JSONObject

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/LoginActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/LoginActivity.kt
@@ -1,6 +1,5 @@
 package com.bookiibookii.bookiibookii.onboarding.login
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -17,6 +16,7 @@ import androidx.credentials.exceptions.GetCredentialException
 import androidx.lifecycle.lifecycleScope
 import com.bookiibookii.bookiibookii.MainActivity
 import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.data.api.AuthInterceptor
 import com.bookiibookii.bookiibookii.data.api.RetrofitClient
 import com.bookiibookii.bookiibookii.data.model.LoginRequest
 import com.bookiibookii.bookiibookii.data.model.MypageResult
@@ -25,7 +25,6 @@ import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.material.card.MaterialCardView
 import com.kakao.sdk.auth.model.OAuthToken
-import com.kakao.sdk.common.KakaoSdk.keyHash
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
@@ -39,65 +38,63 @@ class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // TODO: 온보딩까지 구현 후 삭제
-        Log.d("ONB_FLOW", "token=${hasAccessToken()} done=${isOnboardingDone()}")
+        // 공통 에러/로그아웃 라우팅 잠금 해제
+        AuthInterceptor.unlockRouting()
 
         setContentView(R.layout.activity_login)
-        RetrofitClient.init(this)
-        // =================================================================
-        // [TEST MODE] 하드코딩 토큰 주입 & 메인 강제 이동
-        // =================================================================
-//        Log.d("TEST_MODE", "🛠️ 테스트 모드 가동: 토큰 주입 중...")
-//
-//        val prefs = getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
-//        prefs.edit().apply {
-//            // 1. 개발자에게 받은 토큰을 저장소에 강제로 넣습니다.
-//            putString("access_token", TestTokenConfig.TEST_ACCESS_TOKEN)
-//            putString("refresh_token", TestTokenConfig.TEST_REFRESH_TOKEN)
-//            putInt("user_id", TestTokenConfig.TEST_USER_ID)
-//
-//            // 2. 온보딩도 끝난 것으로 처리합니다.
-//            putBoolean("onboarding_done", true)
-//
-//            // 저장 실행
-//            apply()
-//        }
-//
-//        Log.d("TEST_MODE", "🚀 토큰 주입 완료. 메인으로 이동합니다.")
-//        moveToMain()
-//        return // ★ 중요: 아래 기존 로그인 로직이 실행되지 않도록 여기서 종료
-//         =================================================================
 
-        // 1. 자동 로그인 체크 (토큰이 이미 있으면 메인으로)
-        if (hasAccessToken()) {
-            if (isOnboardingDone()) {
-                moveToMain()
-            } else {
-                moveToOnboarding()
-            }
-            return
-        }
+        // TODO: 추후 로그 삭제 (온보딩/토큰 분기 디버깅용)
+        Log.d(
+            "ONB_FLOW",
+            "token=${TokenManager.hasAccessToken(this)} done=${TokenManager.isOnboardingDone(this)}"
+        )
 
-        // 2. Credential Manager 초기화
+        // 자동 로그인 분기
+        if (routeAutoLoginIfPossible()) return
+
         credentialManager = CredentialManager.create(this)
 
-        setupLoginButtons()
-        Log.e("APP_CHECK", "MyApplication onCreate called")
+        bindLoginButtons()
 
-        Log.e("KeyHash_Check", "내 앱의 현재 키 해시: $keyHash")
+        // TODO: 추후 로그 삭제 (카카오 키해시 확인용)
+        Log.e("KeyHash_Check", "내 앱의 현재 키 해시: ${com.kakao.sdk.common.KakaoSdk.keyHash}")
     }
 
-    private fun setupLoginButtons() {
-        val kakaoButton = findViewById<View>(R.id.btn_kakao_login)
+    private fun routeAutoLoginIfPossible(): Boolean {
+        if (!TokenManager.hasAccessToken(this)) return false
 
-        // [수정] 람다 안에서 함수 호출
-        setupButtonUI(kakaoButton, "카카오로 시작하기", R.drawable.ic_kakao, R.color.kakao, R.color.grey_900) {
+        if (TokenManager.isOnboardingDone(this)) {
+            moveToMain()
+        } else {
+            moveToOnboarding()
+        }
+        return true
+    }
+
+    private fun bindLoginButtons() {
+        val kakaoButton = findViewById<View>(R.id.btn_kakao_login)
+        val googleButton = findViewById<View>(R.id.btn_google_login)
+
+        setupButtonUI(
+            root = kakaoButton,
+            text = "카카오로 시작하기",
+            iconRes = R.drawable.ic_kakao,
+            bgRes = R.color.kakao,
+            textRes = R.color.grey_900
+        ) {
+            if (isNavigating) return@setupButtonUI
+            showLoadingState(true)
             loginToKakao()
         }
 
-        // 구글 버튼은 기존 그대로 둠
-        val googleButton = findViewById<View>(R.id.btn_google_login)
-        setupButtonUI(googleButton, "구글로 시작하기", R.drawable.ic_google, R.color.grey_100, R.color.grey_900) {
+        setupButtonUI(
+            root = googleButton,
+            text = "구글로 시작하기",
+            iconRes = R.drawable.ic_google,
+            bgRes = R.color.grey_100,
+            textRes = R.color.grey_900
+        ) {
+            if (isNavigating) return@setupButtonUI
             showLoadingState(true)
             signInWithGoogle()
         }
@@ -105,12 +102,11 @@ class LoginActivity : AppCompatActivity() {
 
     private fun signInWithGoogle() {
         val webClientId = getString(R.string.web_client_id)
-        Log.d("Login", "Using Web Client ID: $webClientId") // ID 확인용 로그
 
         val googleIdOption = GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false) // 이전에 로그인한 적 없는 계정도 표시
+            .setFilterByAuthorizedAccounts(false)
             .setServerClientId(webClientId)
-            .setAutoSelectEnabled(true) // 가능한 경우 자동 선택
+            .setAutoSelectEnabled(true)
             .build()
 
         val request = GetCredentialRequest.Builder()
@@ -119,95 +115,127 @@ class LoginActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             try {
-                Log.d("Login", "getCredential 요청 시작")
                 val result: GetCredentialResponse = credentialManager.getCredential(
                     request = request,
                     context = this@LoginActivity
                 )
-                Log.d("Login", "getCredential 응답 받음")
-                handleSignIn(result)
+                handleGoogleSignIn(result)
             } catch (e: GetCredentialException) {
+                // TODO: 추후 로그 삭제 (Credential Manager 예외 확인용)
                 Log.e("Login", "Credential Manager 에러: ${e.message}", e)
                 showLoadingState(false)
             } catch (e: Exception) {
+                // TODO: 추후 로그 삭제 (예상치 못한 예외 확인용)
                 Log.e("Login", "예상치 못한 에러", e)
                 showLoadingState(false)
             }
         }
     }
-    private fun handleSignIn(result: GetCredentialResponse) {
+
+    private fun handleGoogleSignIn(result: GetCredentialResponse) {
         val credential = result.credential
 
-        // 구글 인증 정보인지 확인
-        if (credential is CustomCredential && credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-            try {
-                // 토큰 추출
-                val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
-                val idToken = googleIdTokenCredential.idToken
+        val isGoogleToken =
+            credential is CustomCredential &&
+                    credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
 
-                Log.d("Login", "Google ID Token 획득 성공: $idToken")
-
-                //백엔드로 정보 전달
-                // [수정 전] sendTokenToBackend(idToken)
-                // [수정 후] "GOOGLE" 이라고 명찰을 달아서 보냄
-                sendTokenToBackend("GOOGLE", idToken)
-            } catch (e: Exception) {
-                Log.e("Login", "인증 정보 파싱 실패", e)
-                showLoadingState(false)
-            }
-        } else {
+        if (!isGoogleToken) {
+            // TODO: 추후 로그 삭제 (인증 타입 분기 확인용)
             Log.e("Login", "알 수 없는 인증 타입: ${credential.type}")
+            showLoadingState(false)
+            return
+        }
+
+        try {
+            val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(credential.data)
+            val idToken = googleIdTokenCredential.idToken
+            sendTokenToBackend(socialType = "GOOGLE", token = idToken)
+        } catch (e: Exception) {
+            // TODO: 추후 로그 삭제 (구글 토큰 파싱 실패 확인용)
+            Log.e("Login", "인증 정보 파싱 실패", e)
             showLoadingState(false)
         }
     }
 
-    // [수정] socialType 파라미터 추가
-    private fun sendTokenToBackend(socialType: String, token: String) {
+    private fun loginToKakao() {
+        val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+            if (error != null) {
+                // TODO: 추후 로그 삭제 (카카오 로그인 실패 원인 확인용)
+                Log.e("KakaoLogin", "카카오 로그인 실패", error)
+                showLoadingState(false)
+            } else if (token != null) {
+                sendTokenToBackend("KAKAO", token.accessToken)
+            } else {
+                showLoadingState(false)
+            }
+        }
 
-        Log.e("CheckToken", "=========================================")
-        Log.e("CheckToken", "[보내는 타입]: $socialType") // 여기가 GOOGLE 또는 KAKAO로 찍힘
-        Log.e("CheckToken", "[보내는 토큰]: $token")
-        Log.e("CheckToken", "=========================================")
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(this)) {
+            UserApiClient.instance.loginWithKakaoTalk(this) { token, error ->
+                if (error != null) {
+                    // TODO: 추후 로그 삭제 (카카오톡 앱 로그인 실패 원인 확인용)
+                    Log.e("KakaoLogin", "카카오톡 앱 로그인 실패", error)
+
+                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                        showLoadingState(false)
+                        return@loginWithKakaoTalk
+                    }
+
+                    UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
+                    return@loginWithKakaoTalk
+                }
+
+                if (token != null) {
+                    sendTokenToBackend(socialType = "KAKAO", token = token.accessToken)
+                } else {
+                    showLoadingState(false)
+                }
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
+        }
+    }
+
+    private fun sendTokenToBackend(socialType: String, token: String) {
+        // TODO: 추후 로그 삭제 (서버 전송 파라미터 확인용)
+        Log.d("CheckToken", "[보내는 타입]=$socialType, tokenLength=${token.length}")
 
         lifecycleScope.launch {
             try {
-                // "GOOGLE" 대신 받아온 socialType 변수를 넣습니다.
                 val request = LoginRequest(socialType = socialType, token = token)
                 val response = RetrofitClient.api().postLogin(request)
 
                 if (response.isSuccessful && response.body()?.isSuccess == true) {
                     val result = response.body()?.result
-                    Log.d("Login", "로그인 메시지 : $response")
                     if (result != null) {
-                        Log.d("Login", "$socialType 로그인 성공! UserID: ${result.userId}")
-
-                        saveTokens(
+                        TokenManager.saveTokens(
+                            this@LoginActivity,
                             result.accessToken,
                             result.refreshToken,
-                            result.userId,
-                            result.onboardingDone
+                            result.userId
                         )
+                        TokenManager.saveOnboardingDone(this@LoginActivity, result.onboardingDone)
 
-                       onLoginSuccess()
-
+                        onLoginSuccess()
                     } else {
                         showLoadingState(false)
                     }
                 } else {
+                    // TODO: 추후 로그 삭제 (서버 응답 실패 디버깅용)
                     Log.e("Login", "백엔드 에러: ${response.code()} ${response.errorBody()?.string()}")
                     showLoadingState(false)
                 }
             } catch (e: Exception) {
+                // TODO: 추후 로그 삭제 (네트워크/예외 디버깅용)
                 Log.e("Login", "네트워크 오류", e)
                 showLoadingState(false)
             }
         }
     }
 
-    // --- 유틸리티 함수들 ---
-
     private fun onLoginSuccess() {
-        if (isOnboardingDone()) {
+        isNavigating = true
+        if (TokenManager.isOnboardingDone(this)) {
             moveToMain()
         } else {
             moveToOnboarding()
@@ -216,17 +244,17 @@ class LoginActivity : AppCompatActivity() {
 
     private fun showLoadingState(isLoading: Boolean) {
         val buttonsGroup = findViewById<Group>(R.id.group_login_buttons)
-
-        if (isLoading) {
-            buttonsGroup.visibility = View.GONE
-            // progressBar?.visibility = View.VISIBLE
-        } else {
-            buttonsGroup.visibility = View.VISIBLE
-            // progressBar?.visibility = View.GONE
-        }
+        buttonsGroup.visibility = if (isLoading) View.GONE else View.VISIBLE
     }
 
-    private fun setupButtonUI(root: View, text: String, iconRes: Int, bgRes: Int, textRes: Int, onClick: () -> Unit) {
+    private fun setupButtonUI(
+        root: View,
+        text: String,
+        iconRes: Int,
+        bgRes: Int,
+        textRes: Int,
+        onClick: () -> Unit
+    ) {
         val card = root as MaterialCardView
         val tv = root.findViewById<TextView>(R.id.tv_login_text)
         val iv = root.findViewById<ImageView>(R.id.iv_login_icon)
@@ -236,100 +264,33 @@ class LoginActivity : AppCompatActivity() {
         iv.setImageResource(iconRes)
         card.setCardBackgroundColor(getColor(bgRes))
 
-        root.setOnClickListener {
-            if (!isNavigating) onClick()
-        }
+        root.setOnClickListener { onClick() }
     }
 
-    private fun saveTokens(access: String, refresh: String, userId: Int, onboardingDone: Boolean) {
-        val prefs = getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
-        prefs.edit().apply {
-            putString("access_token", access)
-            putString("refresh_token", refresh)
-            putInt("user_id", userId)
-            putBoolean("onboarding_done", onboardingDone)
-            apply()
-        }
-    }
-
-    private fun isOnboardingDone(): Boolean {
-        val prefs = getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
-        return prefs.getBoolean("onboarding_done", false)
-    }
-
-    private fun hasAccessToken(): Boolean {
-        val prefs = getSharedPreferences("auth_prefs", Context.MODE_PRIVATE)
-        return !prefs.getString("access_token", null).isNullOrEmpty()
-    }
-
-    // 여기부터 ~~~~~
-
-    private fun loginToKakao() {
-        showLoadingState(true) // 로딩 시작
-
-        // 공통 콜백 함수
-        val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
-            if (error != null) {
-                Log.e("KakaoLogin", "카카오 로그인 실패", error)
-                showLoadingState(false)
-            } else if (token != null) {
-                Log.i("KakaoLogin", "카카오 로그인 성공 -> 서버 전송")
-
-                // ★★★ 여기가 핵심! 카카오 토큰을 서버로 보냄 ★★★
-                sendTokenToBackend("KAKAO", token.accessToken)
-            }
-        }
-
-        // 카카오톡 앱이 있으면 앱으로, 없으면 웹으로 로그인
-        if (UserApiClient.instance.isKakaoTalkLoginAvailable(this)) {
-            UserApiClient.instance.loginWithKakaoTalk(this) { token, error ->
-                if (error != null) {
-                    Log.e("KakaoLogin", "카카오톡 앱 로그인 실패", error)
-
-                    // 사용자가 취소했을 때
-                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                        showLoadingState(false)
-                        return@loginWithKakaoTalk
-                    }
-                    // 실패하면 웹으로 재시도
-                    UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
-                } else if (token != null) {
-                    Log.i("KakaoLogin", "카카오톡 앱 로그인 성공")
-
-                    // ★★★ 앱 로그인 성공 시 서버 전송 ★★★
-                    sendTokenToBackend("KAKAO", token.accessToken)
-                }
-            }
-        } else {
-            UserApiClient.instance.loginWithKakaoAccount(this, callback = callback)
-        }
-    }
-
-    // 메인 화면으로 이동하는 함수
     private fun moveToMain() {
-        val intent = Intent(this, MainActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
         startActivity(intent)
         finish()
     }
 
     private fun moveToOnboarding() {
-        val intent = Intent(this, OnbProfileActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        val intent = Intent(this, OnbProfileActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
         startActivity(intent)
         finish()
     }
-//    object TestTokenConfig {
-//        // 백엔드 개발자에게 받은 토큰을 여기에 붙여넣으세요 (공백 주의)
-//        const val TEST_ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyIiwidHlwZSI6ImFjY2VzcyIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzcwNjg5NDUyLCJleHAiOjE3NzA2OTEyNTJ9.Mgm81NRBGDy-er_-P8wrR7roV-WkmgY0JsGSLu_GLIg"
-//        const val TEST_REFRESH_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwidHlwZSI6InJlZnJlc2giLCJpYXQiOjE3NzA2MjU5MzEsImV4cCI6MTc3MTgzNTUzMX0.V_OEoWL4jJt2JQ36ZwVzn7ypPd7P6Z8ioRXbPYnH23g"
-//        const val TEST_USER_ID = 1 // 테스트할 유저 ID (임의로 1 또는 실제 ID)
-//    }
 
     data class ProfileResponse(
         val isSuccess: Boolean,
         val code: String,
         val message: String,
-        val result: MypageResult? // 기존 MypageResult를 재사용하거나 아래 구조로 수정
+        val result: MypageResult?
     )
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/MyApplication.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/MyApplication.kt
@@ -1,4 +1,5 @@
 package com.bookiibookii.bookiibookii.onboarding.login
+
 import android.app.Application
 import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
@@ -1,0 +1,47 @@
+package com.bookiibookii.bookiibookii.onboarding.login
+
+import android.content.Context
+
+object TokenManager {
+
+    private const val PREF = "auth_prefs"
+    private const val KEY_ACCESS = "access_token"
+    private const val KEY_REFRESH = "refresh_token"
+    private const val KEY_USER_ID = "user_id"
+    private const val KEY_ONBOARDING = "onboarding_done"
+
+    fun saveTokens(context: Context, access: String, refresh: String, userId: Int) {
+        val prefs = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        prefs.edit().apply {
+            putString(KEY_ACCESS, access)
+            putString(KEY_REFRESH, refresh)
+            putInt(KEY_USER_ID, userId)
+            apply()
+        }
+    }
+
+    fun saveOnboardingDone(context: Context, onboardingDone: Boolean) {
+        val prefs = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(KEY_ONBOARDING, onboardingDone).apply()
+    }
+
+    fun hasAccessToken(context: Context): Boolean {
+        val prefs = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        return !prefs.getString(KEY_ACCESS, null).isNullOrEmpty()
+    }
+
+    fun isOnboardingDone(context: Context): Boolean {
+        val prefs = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        return prefs.getBoolean(KEY_ONBOARDING, false)
+    }
+
+    fun getRefreshToken(context: Context): String? {
+        val prefs = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        return prefs.getString(KEY_REFRESH, null)
+    }
+
+    fun clear(context: Context) {
+        val prefs = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        prefs.edit().clear().apply()
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request Title
feat: 토큰 자동 재발급 및 공통 에러 라우팅 구조 적용  

---

# ✨ 작업 내용 (What)
1. AccessToken 자동 재발급 로직 구현
   - AuthInterceptor에 401 응답 시 refresh 자동 요청 로직 추가
   - refresh 성공 시 accessToken/refreshToken 재저장 후 원 요청 재시도
   - refresh 실패 시 INVALID / NETWORK / SYSTEM 케이스 분기 처리

2. 공통 에러 화면 연동
   - 서버 5xx → ComErrorActivity(TYPE_SYSTEM_ERROR) 이동
   - refresh 네트워크 실패 → TYPE_NETWORK_ERROR 이동
   - refresh 토큰 만료 → 강제 로그아웃 처리
   - AtomicBoolean 기반 라우팅 중복 실행 방지 적용

3. RetryBus 기반 재시도 구조 추가
   - ComRetryBus 추가 (SharedFlow 기반)
   - ComErrorActivity에서 [다시 시도] 클릭 시 retryFlow emit
   - Notification 화면에서 retryFlow 수신 후 loadFirstPage() 재요청

4. Notification 화면 에러 처리 개선
   - 기존 errorType 기반 ComError 호출 유지
   - RetryBus 수신 시 자동 재요청 처리

5. LoginActivity 구조 정리
   - 자동 로그인 분기 함수화 (routeAutoLoginIfPossible)
   - 로그인 버튼 바인딩 구조 정리
   - 불필요한 중복 로직 제거
   - 디버깅 로그에 // TODO: 추후 로그 삭제 주석 추가

---

# 🧪 테스트 방법 (How to Test)
1. 토큰 재발급 확인
   - 로그인 성공
   - 서버에서 accessToken 만료 시간 짧게 설정하거나
   - 만료된 accessToken을 강제로 SharedPreferences에 저장
   - 보호된 API 호출 (예: 알림 조회)
      → 401 발생
      → refresh 자동 요청
      → 새로운 accessToken 저장
      → 원 요청 재시도
      → 정상 응답 확인

2. refresh 실패 테스트
   - refreshToken 삭제 후 API 호출
      → 자동 로그아웃 → LoginActivity 이동 확인

3. 네트워크 오류 테스트
   서버 끄거나 인터넷 차단 후 API 호출
      → ComErrorActivity (네트워크 오류) 화면 노출 확인
      → [다시 시도] 클릭 시 API 재요청 확인

4. 서버 500 테스트
   서버에서 강제로 500 반환하도록 설정
      → ComErrorActivity (시스템 오류) 화면 노출 확인

---

# 💡추가 사항
- 추후 릴리즈 시 디버그 로그 제거 필요

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #142
