### PR TITLE
fix: 온보딩 프포필 버튼 및 이미지 클립 처리 수정

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/RetrofitClient.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/RetrofitClient.kt
@@ -9,6 +9,10 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
 object RetrofitClient {
+    // main 도메인 주소
+//    private const val BASE_URL = "https://bookiibookii.gyeonseo.com/"
+
+    // dev 도메인 주소
     private const val BASE_URL = "https://bookii.gyeonseo.com/"
 
     @Volatile private var apiService: ApiService? = null

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/profile/OnbProfileActivity.kt
@@ -85,7 +85,10 @@ class OnbProfileActivity : AppCompatActivity() {
     // 초기 UI 상태 설정
     private fun initView() {
         binding.btnCheck.isEnabled = false
-        binding.includeFooterButton.btnFooter.isEnabled = false
+        binding.includeFooterButton.btnOnbFooter.apply {
+            text = "다음"
+            isEnabled = false
+        }
         binding.layoutValidation.visibility = View.GONE
     }
 
@@ -97,7 +100,7 @@ class OnbProfileActivity : AppCompatActivity() {
 
             // 입력 변경 시 중복 확인 상태 초기화
             isNicknameChecked = false
-            binding.includeFooterButton.btnFooter.isEnabled = false
+            binding.includeFooterButton.btnOnbFooter.isEnabled = false
             binding.layoutValidation.visibility = View.GONE
 
             // 형식이 유효한 경우에만 중복 확인 버튼 활성화
@@ -133,7 +136,7 @@ class OnbProfileActivity : AppCompatActivity() {
         }
 
         // 다음 버튼 클릭
-        binding.includeFooterButton.btnFooter.setOnClickListener {
+        binding.includeFooterButton.btnOnbFooter.setOnClickListener {
             if (!isNicknameChecked) return@setOnClickListener
 
             val nickname = binding.etNickname.text.toString().trim()
@@ -154,7 +157,7 @@ class OnbProfileActivity : AppCompatActivity() {
 
                 NicknameCheckState.Loading -> {
                     binding.btnCheck.isEnabled = false
-                    binding.includeFooterButton.btnFooter.isEnabled = false
+                    binding.includeFooterButton.btnOnbFooter.isEnabled = false
                     binding.layoutValidation.visibility = View.GONE
                 }
 
@@ -181,19 +184,19 @@ class OnbProfileActivity : AppCompatActivity() {
 
                 ProfileImageUploadState.Loading -> {
                     binding.ivProfileEdit.isEnabled = false
-                    binding.includeFooterButton.btnFooter.isEnabled = false
+                    binding.includeFooterButton.btnOnbFooter.isEnabled = false
                 }
 
                 is ProfileImageUploadState.Success -> {
                     uploadedS3Key = state.s3Key
                     binding.ivProfileEdit.isEnabled = true
-                    binding.includeFooterButton.btnFooter.isEnabled = isNicknameChecked
+                    binding.includeFooterButton.btnOnbFooter.isEnabled = isNicknameChecked
                     showCustomToast("프로필 이미지가 업로드되었습니다.")
                 }
 
                 is ProfileImageUploadState.Error -> {
                     binding.ivProfileEdit.isEnabled = true
-                    binding.includeFooterButton.btnFooter.isEnabled = isNicknameChecked
+                    binding.includeFooterButton.btnOnbFooter.isEnabled = isNicknameChecked
                     showCustomToast(message = state.message)
                 }
             }
@@ -220,7 +223,7 @@ class OnbProfileActivity : AppCompatActivity() {
         binding.tvValidation.text = message
         binding.tvValidation.setTextColor("#00C317".toColorInt())
 
-        binding.includeFooterButton.btnFooter.isEnabled = true
+        binding.includeFooterButton.btnOnbFooter.isEnabled = true
     }
 
     // 닉네임 오류 UI 처리
@@ -236,7 +239,7 @@ class OnbProfileActivity : AppCompatActivity() {
         binding.tvValidation.text = message
         binding.tvValidation.setTextColor(getColor(R.color.ui_point_red))
 
-        binding.includeFooterButton.btnFooter.isEnabled = false
+        binding.includeFooterButton.btnOnbFooter.isEnabled = false
     }
 
     // 닉네임 형식 검증

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
@@ -65,8 +65,17 @@ class OnbStepActivity : AppCompatActivity() {
         progress1 = findViewById(R.id.progress1)
         progress2 = findViewById(R.id.progress2)
         progress3 = findViewById(R.id.progress3)
-        btnNext = findViewById(R.id.btn_footer)
+
+        // 1순위: 원래 의도(btn_footer)
+        val btn1 = findViewById<MaterialButton>(R.id.btn_onb_footer)
+
+        // 2순위: 현재 기기에서 실제로 존재하는 버튼(id가 include_footer_button로 되어있는 케이스)
+        val btn2 = findViewById<MaterialButton>(R.id.include_footer_button)
+
+        btnNext = btn1 ?: btn2 ?: throw IllegalStateException("Next button not found")
     }
+
+
 
     // 클릭 이벤트 바인딩
     private fun bindActions() {

--- a/app/src/main/res/drawable/bg_onb_profile.xml
+++ b/app/src/main/res/drawable/bg_onb_profile.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="40dp"/>
+    <solid android:color="@color/ui_bg"/>
+</shape>

--- a/app/src/main/res/drawable/ic_profile.xml
+++ b/app/src/main/res/drawable/ic_profile.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="20dp"
-    android:height="20dp"
+    android:width="128dp"
+    android:height="128dp"
     android:viewportWidth="20"
     android:viewportHeight="20">
   <path

--- a/app/src/main/res/layout/activity_onb_profile.xml
+++ b/app/src/main/res/layout/activity_onb_profile.xml
@@ -36,9 +36,10 @@
             android:id="@+id/iv_profile"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="@drawable/bg_onb_profile"
+            android:clipToOutline="true"
             android:src="@drawable/img_profile_default"
-            android:scaleType="centerCrop"
-            android:clipToOutline="true" />
+            android:scaleType="centerCrop" />
 
         <ImageView
             android:id="@+id/iv_profile_edit"

--- a/app/src/main/res/layout/include_onb_button.xml
+++ b/app/src/main/res/layout/include_onb_button.xml
@@ -2,7 +2,7 @@
 <com.google.android.material.button.MaterialButton xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tool="http://schemas.android.com/tools"
-    android:id="@+id/btn_footer"
+    android:id="@+id/btn_onb_footer"
     android:layout_width="match_parent"
     android:layout_height="72dp"
     android:textAllCaps="false"
@@ -16,6 +16,5 @@
     android:letterSpacing="-0.02"
     app:backgroundTint="@null"
     android:textSize="16sp"
-    android:text="next"
     android:stateListAnimator="@null"
     tool:text="다음" />


### PR DESCRIPTION
# 📌 Pull Request Title
fix: 온보딩 프포필 버튼 및 이미지 클립 처리 수정

---

# ✨ 작업 내용 (What)
- include_onb_button 내부 버튼 id를 btn_onb_footer로 변경하여 id 중복 문제 해결
- 변경된 id를 OnbProfileActivity / OnbStepActivity에 반영
- 온보딩 프로필 화면 하단 버튼 텍스트를 코드에서 설정하도록 수정
- 프로필 이미지에 라운드 클립 적용 (사용자 설정 이미지 포함)

---

# 🧪 테스트 방법 (How to Test)
1. 앱 실행 → 로그인 → 온보딩 프로필 화면 진입
2. 닉네임 중복 확인 후 하단 버튼 텍스트 정상 노출 확인
3. 갤러리/카메라로 프로필 이미지 변경
4. 변경된 이미지에 굴곡(라운드 클립)이 정상 적용되는지 확인

---

# 💡추가 사항
- 테스트를 위해 dev 도메인 주소로 입력되어있음

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #197 
