### PR TITLE
ui: 스플래쉬/로그인 바텀마진 적용(#232), 온보딩 과정은 확인 필요

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/common/SplashActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/common/SplashActivity.kt
@@ -3,6 +3,7 @@ package com.bookiibookii.bookiibookii.common
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
@@ -17,22 +18,33 @@ import kotlinx.coroutines.launch
 import kotlin.jvm.java
 
 @SuppressLint("CustomSplashScreen")
-class SplashActivity : AppCompatActivity() {
+class SplashActivity : BaseActivity<ActivitySplashBinding>() {
 
-    private lateinit var binding: ActivitySplashBinding
+    override fun getViewBinding(): ActivitySplashBinding {
+        return ActivitySplashBinding.inflate(layoutInflater)
+    }
+
+
+    override fun setupWindowInsets(view: View) {
+        // 아무것도 안함 → 완전 풀스크린, 필요없다면 제거 필요
+    }
+
+   // private lateinit var binding: ActivitySplashBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
 
-        binding = ActivitySplashBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+//        binding = ActivitySplashBinding.inflate(layoutInflater)
+//        setContentView(binding.root)
 
         lifecycleScope.launch {
             delay(2000L)
             routeNext()
         }
     }
+
+
 
     private fun routeNext() {
         val hasToken = TokenManager.hasAccessToken(this)
@@ -58,4 +70,5 @@ class SplashActivity : AppCompatActivity() {
         startActivity(intent)
         finish()
     }
+
 }


### PR DESCRIPTION
# 📌 Pull Request Title
> **`<<ui>`: `<스플래쉬/로그인 바텀마진 적용>`**

---

# ✨ 작업 내용 (What)
> - 변경된 내용을 한 줄씩 정확하게 작성해주세요.
> - 화면/기능 단위로 bullet point를 사용해주세요.
> - UI가 변경되었거나 추가된 경우 반드시 이미지 첨부

- 최초 로딩 -> 스플래쉬 -> 로그인 화면 Edge-To-Edge 적용
- ERR 화면도 수정은 했는데, 확인은 못함.
- 온보딩 화면은 상태를 모르겠어서(새 카톡으로 해봐야할듯 일단 보류)

---
<img width="380" height="733" alt="스크린샷 2026-03-30 오후 10 10 43" src="https://github.com/user-attachments/assets/b6d9487b-3dc1-435a-90de-176806d5fbbb" />
<img width="357" height="736" alt="스크린샷 2026-03-30 오후 10 10 48" src="https://github.com/user-attachments/assets/b62b2332-1b3b-49b0-a2a6-9378f2432bde" />


# 🧪 테스트 방법 (How to Test)

- 앱실행간 정상 확인
---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!
- 로그인 아래 부가설명? 부분 겹치는 거 같은데 수정 부탁드립니다.
- BaseActivity 적용하려했는데 findViewById랑 호환성 떨어진다고 해서 최대한 조율해봄 (주석처리 해뒀슴다)
---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: #232 