### PR TITLE
ui: 그룹 검색 화면 제작 (#285)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,5 +135,6 @@ dependencies {
     implementation("androidx.compose.material:material-icons-core")
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0")
+    implementation("androidx.navigation:navigation-compose:2.8.5")
     debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/GroupFragment.kt
@@ -1,0 +1,27 @@
+package com.bookiibookii.bookiibookii.group
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import com.bookiibookii.bookiibookii.group.nav.GroupNavHost
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+class GroupFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = ComposeView(requireContext()).apply {
+        // Fragment view 생명주기에 맞춰 컴포지션 폐기 (백스택 복귀 시 누수 방지)
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        setContent {
+            BookiiBookiiTheme {
+                GroupNavHost()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupDestinations.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupDestinations.kt
@@ -1,0 +1,19 @@
+package com.bookiibookii.bookiibookii.group.nav
+
+object GroupDestinations {
+
+    const val ARG_GROUP_ID = "groupId"
+
+    const val SEARCH = "search"
+    const val DETAIL = "detail/{$ARG_GROUP_ID}"
+    const val EDITOR = "editor?$ARG_GROUP_ID={$ARG_GROUP_ID}"
+    const val JOIN_REQUESTS = "joinRequests/{$ARG_GROUP_ID}"
+
+    fun detail(groupId: String) = "detail/$groupId"
+
+    // groupId == null -> 생성, not null -> 수정
+    fun editor(groupId: String? = null) =
+        if (groupId == null) "editor" else "editor?$ARG_GROUP_ID=$groupId"
+
+    fun joinRequests(groupId: String) = "joinRequests/$groupId"
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
@@ -1,0 +1,25 @@
+package com.bookiibookii.bookiibookii.group.nav
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.bookiibookii.bookiibookii.group.ui.search.GroupSearchScreen
+
+@Composable
+fun GroupNavHost(
+    modifier: Modifier = Modifier,
+    startDestination: String = GroupDestinations.SEARCH,
+) {
+    val navController = rememberNavController()
+    NavHost(
+        navController = navController,
+        startDestination = startDestination,
+        modifier = modifier,
+    ) {
+        composable(GroupDestinations.SEARCH) {
+            GroupSearchScreen()
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
@@ -1,0 +1,7 @@
+package com.bookiibookii.bookiibookii.group.ui.detail
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun GroupDetailScreen() {
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/editor/GroupEditorScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/editor/GroupEditorScreen.kt
@@ -1,0 +1,7 @@
+package com.bookiibookii.bookiibookii.group.ui.editor
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun GroupEditorScreen() {
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/joinrequest/GroupJoinRequestScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/joinrequest/GroupJoinRequestScreen.kt
@@ -1,0 +1,7 @@
+package com.bookiibookii.bookiibookii.group.ui.joinrequest
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun GroupJoinRequestScreen() {
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExchangeMethodBottomSheet.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExchangeMethodBottomSheet.kt
@@ -1,0 +1,114 @@
+package com.bookiibookii.bookiibookii.group.ui.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetChip
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetTwoBtnShort
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 교환 방식 필터 바텀시트
+@Composable
+fun ExchangeMethodBottomSheet(
+    modifier: Modifier = Modifier,
+) {
+    val sheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+    val options = listOf("전체", "직접 교환", "택배 교환")
+    var selectedIndex by remember { mutableIntStateOf(0) }
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = BookiiBookiiTheme.colors.white, shape = sheetShape)
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .size(width = 44.dp, height = 4.dp)
+                    .background(
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = BookiiBookiiTheme.shape.round50,
+                    ),
+            )
+            Row(
+                modifier = Modifier.padding(bottom = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "교환 방식",
+                    style = BookiiBookiiTheme.typography.semibold20,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+                Text(
+                    text = options[selectedIndex],
+                    style = BookiiBookiiTheme.typography.regular16,
+                    color = BookiiBookiiTheme.colors.uiMain,
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            options.forEachIndexed { index, label ->
+                BottomSheetChip(
+                    text = label,
+                    selected = index == selectedIndex,
+                    onClick = { selectedIndex = index },
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            BottomSheetTwoBtnShort(
+                text = "취소",
+                style = BottomSheetBtnStyle.White,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+            BottomSheetTwoBtnShort(
+                text = "적용",
+                style = BottomSheetBtnStyle.Dark,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun ExchangeMethodBottomSheetPreview() {
+    BookiiPreview {
+        ExchangeMethodBottomSheet()
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
@@ -1,0 +1,167 @@
+package com.bookiibookii.bookiibookii.group.ui.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+@Composable
+fun ExploreGroupCard(
+    title: String,
+    author: String,
+    category: String,
+    exchangeType: String,
+    expectedDays: Int,
+    nickname: String,
+    groupName: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(BookiiBookiiTheme.shape.round20)
+            .background(BookiiBookiiTheme.colors.white)
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // 책 썸네일 placeholder
+        Box(
+            modifier = Modifier
+                .size(width = 72.dp, height = 100.dp)
+                .clip(BookiiBookiiTheme.shape.round8)
+                .background(BookiiBookiiTheme.colors.uiBg),
+        )
+
+        Column(
+            modifier = Modifier
+                .height(100.dp)
+                .weight(1f),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    ExchangeTypeBadge(text = exchangeType)
+                    Text(
+                        text = title,
+                        style = BookiiBookiiTheme.typography.medium16,
+                        color = BookiiBookiiTheme.colors.grey900,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Text(
+                    text = "$author($category)",
+                    style = BookiiBookiiTheme.typography.regular14,
+                    color = BookiiBookiiTheme.colors.grey500,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        text = "예상 독서 기간",
+                        style = BookiiBookiiTheme.typography.regular14,
+                        color = BookiiBookiiTheme.colors.grey700,
+                    )
+                    Row {
+                        Text(
+                            text = "$expectedDays",
+                            style = BookiiBookiiTheme.typography.regular14,
+                            color = BookiiBookiiTheme.colors.grey800,
+                        )
+                        Text(
+                            text = "일",
+                            style = BookiiBookiiTheme.typography.regular14,
+                            color = BookiiBookiiTheme.colors.grey700,
+                        )
+                    }
+                }
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    // 프로필 이미지 placeholder
+                    Box(
+                        modifier = Modifier
+                            .size(20.dp)
+                            .clip(BookiiBookiiTheme.shape.round50)
+                            .background(BookiiBookiiTheme.colors.uiBg),
+                    )
+                    Text(
+                        text = nickname,
+                        style = BookiiBookiiTheme.typography.regular15,
+                        color = BookiiBookiiTheme.colors.grey700,
+                    )
+                    Text(
+                        text = "·",
+                        style = BookiiBookiiTheme.typography.regular15,
+                        color = BookiiBookiiTheme.colors.grey700,
+                    )
+                    Text(
+                        text = groupName,
+                        style = BookiiBookiiTheme.typography.regular15,
+                        color = BookiiBookiiTheme.colors.grey500,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// 카드 내부 교환 방식 라벨 배지
+@Composable
+private fun ExchangeTypeBadge(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .clip(BookiiBookiiTheme.shape.round8)
+            .background(BookiiBookiiTheme.colors.uiMainPale)
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium11,
+            color = BookiiBookiiTheme.colors.uiMain,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ExploreGroupCardPreview() {
+    BookiiPreview {
+        ExploreGroupCard(
+            title = "살인자의 기억법",
+            author = "김영하",
+            category = "한국소설",
+            exchangeType = "직접",
+            expectedDays = 7,
+            nickname = "닉네임",
+            groupName = "그룹명",
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.unit.dp
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
+
+// 그룹 검색 메인 카드 아이템
 @Composable
 fun ExploreGroupCard(
     title: String,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GenreBottomSheet.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GenreBottomSheet.kt
@@ -1,0 +1,240 @@
+package com.bookiibookii.bookiibookii.group.ui.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetChip
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetTwoBtnShort
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+private const val ALL = "전체"
+private const val LITERATURE = "문학"
+private const val NON_LITERATURE = "비문학"
+
+private val categories = listOf(ALL, LITERATURE, NON_LITERATURE)
+
+private val literatureGenres = listOf(
+    "한국소설", "세계소설", "장르소설", "로맨스", "역사소설", "시/에세이", "희곡/문학", "기타",
+)
+private val nonLiteratureGenres = listOf(
+    "경제/경영", "과학/IT", "인문/역사", "가정/취미", "예술/문화", "자기계발", "정치/사회", "기타",
+)
+
+private fun genresOf(category: String?): List<String> = when (category) {
+    LITERATURE -> literatureGenres
+    NON_LITERATURE -> nonLiteratureGenres
+    else -> emptyList()
+}
+
+private fun headSummary(category: String?, subs: Set<String>, orderedGenres: List<String>): String {
+    if (category == null) return ""
+    if (category == ALL || subs.isEmpty()) return category
+    val ordered = orderedGenres.filter { it in subs }
+    val body = if (ordered.size <= 3) {
+        ordered.joinToString(" · ")
+    } else {
+        ordered.take(3).joinToString(" · ") + " 외 ${ordered.size - 3}개"
+    }
+    return "$category | $body"
+}
+
+// 장르 필터 바텀시트
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun GenreBottomSheet(
+    modifier: Modifier = Modifier,
+) {
+    val sheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+    var selectedCategory by remember { mutableStateOf<String?>(null) }
+    var selectedSubs by remember { mutableStateOf(setOf<String>()) }
+
+    val subGenres = genresOf(selectedCategory)
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = BookiiBookiiTheme.colors.white, shape = sheetShape)
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .size(width = 44.dp, height = 4.dp)
+                    .background(
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = BookiiBookiiTheme.shape.round50,
+                    ),
+            )
+            Row(
+                modifier = Modifier.padding(bottom = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "장르",
+                    style = BookiiBookiiTheme.typography.semibold20,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+                Text(
+                    text = headSummary(selectedCategory, selectedSubs, subGenres),
+                    style = BookiiBookiiTheme.typography.regular14,
+                    color = BookiiBookiiTheme.colors.uiMain,
+                    maxLines = 1,
+                )
+            }
+        }
+
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                categories.forEachIndexed { index, category ->
+                    BottomSheetChip(
+                        text = category,
+                        selected = selectedCategory == category,
+                        onClick = {
+                            selectedCategory = category
+                            selectedSubs = emptySet()
+                        },
+                    )
+                    if (index < categories.lastIndex) {
+                        Box(
+                            modifier = Modifier
+                                .width(1.dp)
+                                .height(32.dp)
+                                .background(BookiiBookiiTheme.colors.grey200),
+                        )
+                    }
+                }
+            }
+
+            if (subGenres.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    maxItemsInEachRow = 4,
+                ) {
+                    subGenres.forEach { genre ->
+                        GenreSubChip(
+                            text = genre,
+                            selected = genre in selectedSubs,
+                            onClick = {
+                                selectedSubs = if (genre in selectedSubs) {
+                                    selectedSubs - genre
+                                } else {
+                                    selectedSubs + genre
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            BottomSheetTwoBtnShort(
+                text = "취소",
+                style = BottomSheetBtnStyle.White,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+            BottomSheetTwoBtnShort(
+                text = "적용",
+                style = BottomSheetBtnStyle.Dark,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+// 하위 장르 칩. 선택 시 pale 스타일
+@Composable
+private fun GenreSubChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = BookiiBookiiTheme.shape.round50
+    Box(
+        modifier = modifier
+            .height(46.dp)
+            .widthIn(min = 60.dp)
+            .clip(shape)
+            .background(
+                if (selected) {
+                    BookiiBookiiTheme.colors.uiMainPale
+                } else {
+                    BookiiBookiiTheme.colors.white
+                },
+            )
+            .border(
+                width = 1.dp,
+                color = if (selected) {
+                    BookiiBookiiTheme.colors.uiMain150
+                } else {
+                    BookiiBookiiTheme.colors.grey200
+                },
+                shape = shape,
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium16,
+            color = if (selected) {
+                BookiiBookiiTheme.colors.uiMain
+            } else {
+                BookiiBookiiTheme.colors.grey900
+            },
+            maxLines = 1,
+        )
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun GenreBottomSheetPreview() {
+    BookiiPreview {
+        GenreBottomSheet()
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
@@ -1,7 +1,117 @@
 package com.bookiibookii.bookiibookii.group.ui.search
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.component.FilterChip
+import com.bookiibookii.bookiibookii.ui.component.SearchInputButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
+// 그룹 검색 화면
 @Composable
 fun GroupSearchScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BookiiBookiiTheme.colors.uiBg),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BookiiBookiiTheme.colors.white)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = {},
+                    modifier = Modifier.size(40.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_chevron),
+                        contentDescription = "뒤로가기",
+                        tint = BookiiBookiiTheme.colors.grey900,
+                    )
+                }
+                SearchInputButton(
+                    onClick = {},
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(text = "교환 방식", selected = false, onClick = {})
+                FilterChip(text = "지역별", selected = false, onClick = {})
+                FilterChip(text = "분야별", selected = false, onClick = {})
+            }
+        }
+
+        // 더미 데이터
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = "3 권",
+                style = BookiiBookiiTheme.typography.regular14,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            ExploreGroupCard(
+                title = "살인자의 기억법",
+                author = "김영하",
+                category = "한국소설",
+                exchangeType = "직접",
+                expectedDays = 7,
+                nickname = "닉네임",
+                groupName = "그룹명",
+            )
+            ExploreGroupCard(
+                title = "참을 수 없는 존재의 가벼움",
+                author = "밀란 쿤데라",
+                category = "세계소설",
+                exchangeType = "택배",
+                expectedDays = 7,
+                nickname = "kanghunsim",
+                groupName = "자연과 함께 하는 삶",
+            )
+            ExploreGroupCard(
+                title = "작별인사",
+                author = "김영하",
+                category = "한국소설",
+                exchangeType = "직접",
+                expectedDays = 7,
+                nickname = "sayo",
+                groupName = "김영하 도장깨기 하실 분",
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 412, heightDp = 917, showBackground = true)
+@Composable
+private fun GroupSearchScreenPreview() {
+    BookiiPreview {
+        GroupSearchScreen()
+    }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
@@ -1,0 +1,7 @@
+package com.bookiibookii.bookiibookii.group.ui.search
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun GroupSearchScreen() {
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/RegionBottomSheet.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/RegionBottomSheet.kt
@@ -1,0 +1,267 @@
+package com.bookiibookii.bookiibookii.group.ui.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetChip
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetTwoBtnShort
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+private const val NATIONWIDE = "전국"
+private const val ALL = "전체"
+
+private data class City(val name: String, val districts: List<String>)
+
+private val cities = listOf(
+    City("서울", listOf(ALL, "강남구", "강동구", "강북구", "강서구", "관악구", "광진구", "구로구", "금천구", "노원구", "도봉구", "동대문구", "동작구", "마포구", "서대문구", "서초구", "성동구", "성북구", "송파구", "양천구", "영등포구", "용산구", "은평구", "종로구", "중구", "중랑구")),
+    City("경기", listOf(ALL, "수원시", "성남시", "의정부시", "안양시", "부천시", "광명시", "평택시", "동두천시", "안산시", "고양시", "과천시", "구리시", "남양주시", "오산시", "시흥시", "군포시", "의왕시", "하남시", "용인시", "파주시", "이천시", "안성시", "김포시", "화성시", "광주시", "양주시", "포천시", "여주시", "연천군", "가평군", "양평군")),
+    City("인천", listOf(ALL, "계양구", "미추홀구", "남동구", "동구", "부평구", "서구", "연수구", "중구", "강화군·옹진군")),
+    City("대전", listOf(ALL, "대덕구", "동구", "서구", "유성구", "중구")),
+    City("대구", listOf(ALL, "남구", "달서구", "동구", "북구", "서구", "수성구", "중구", "달성군", "군위군")),
+    City("광주", listOf(ALL, "광산구", "남구", "동구", "북구", "서구")),
+    City("울산", listOf(ALL, "남구", "동구", "북구", "중구", "울주군")),
+    City("부산", listOf(ALL, "강서구", "금정구", "남구", "동구", "동래구", "부산진구", "북구", "사상구", "사하구", "서구", "수영구", "연제구", "영도구", "중구", "해운대구", "기장군")),
+    City("세종", listOf(ALL, "세종특별자치시")),
+    City("강원", listOf(ALL, "춘천시", "원주시", "강릉시", "동해시", "태백시", "속초시", "삼척시", "홍천군", "횡성군", "영월군", "평창군", "정선군", "철원군", "화천군", "양구군", "인제군", "고성군", "양양군")),
+    City("충북", listOf(ALL, "청주시", "충주시", "제천시", "보은군", "옥천군", "영동군", "증평군", "진천군", "괴산군", "음성군", "단양군")),
+    City("충남", listOf(ALL, "천안시", "공주시", "보령시", "아산시", "서산시", "논산시", "계룡시", "당진시", "금산군", "부여군", "서천군", "청양군", "홍성군", "예산군", "태안군")),
+    City("전북", listOf(ALL, "전주시", "군산시", "익산시", "정읍시", "남원시", "김제시", "완주군", "진안군", "무주군", "장수군", "임실군", "순창군", "고창군", "부안군")),
+    City("전남", listOf(ALL, "목포시", "여수시", "순천시", "나주시", "광양시", "담양군", "곡성군", "구례군", "고흥군", "보성군", "화순군", "장흥군", "강진군", "해남군", "영암군", "무안군", "함평군", "영광군", "장성군", "완도군", "진도군", "신안군")),
+    City("경북", listOf(ALL, "포항시", "경주시", "김천시", "안동시", "구미시", "영주시", "영천시", "상주시", "문경시", "경산시", "의성군", "청송군", "영양군", "영덕군", "청도군", "고령군", "성주군", "칠곡군", "예천군", "봉화군", "울진군", "울릉군")),
+    City("경남", listOf(ALL, "창원시", "진주시", "통영시", "사천시", "김해시", "밀양시", "거제시", "양산시", "의령군", "함안군", "창녕군", "고성군", "남해군", "하동군", "산청군", "함양군", "거창군", "합천군")),
+    City("제주", listOf(ALL, "제주시", "서귀포시")),
+)
+
+// 구역 칩 토글: "전체"는 구체 구역과 상호배타, 선택은 항상 1개 이상 유지
+private fun toggleDistrict(current: Set<String>, district: String): Set<String> {
+    if (district == ALL) return setOf(ALL)
+    val base = current - ALL
+    val next = if (district in base) base - district else base + district
+    return if (next.isEmpty()) setOf(ALL) else next
+}
+
+private fun headSummary(
+    selectedRegion: String,
+    city: City?,
+    selectedDistricts: Set<String>,
+): String {
+    if (selectedRegion == NATIONWIDE || city == null) return NATIONWIDE
+    if (selectedDistricts.contains(ALL) || selectedDistricts.isEmpty()) return "${city.name} | $ALL"
+    val ordered = city.districts.filter { it != ALL && it in selectedDistricts }
+    val body = if (ordered.size <= 3) {
+        ordered.joinToString(" · ")
+    } else {
+        ordered.take(3).joinToString(" · ") + " 외 ${ordered.size - 3}개"
+    }
+    return "${city.name} | $body"
+}
+
+// 지역 필터 바텀시트
+// UI + 선택 로직, 텍스트 고정
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun RegionBottomSheet(
+    modifier: Modifier = Modifier,
+) {
+    val sheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+    var selectedRegion by remember { mutableStateOf(NATIONWIDE) }
+    var selectedDistricts by remember { mutableStateOf(setOf(ALL)) }
+
+    val currentCity = cities.firstOrNull { it.name == selectedRegion }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = BookiiBookiiTheme.colors.white, shape = sheetShape)
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .size(width = 44.dp, height = 4.dp)
+                    .background(
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = BookiiBookiiTheme.shape.round50,
+                    ),
+            )
+            Row(
+                modifier = Modifier.padding(bottom = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "지역",
+                    style = BookiiBookiiTheme.typography.semibold20,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+                Text(
+                    text = headSummary(selectedRegion, currentCity, selectedDistricts),
+                    style = BookiiBookiiTheme.typography.regular16,
+                    color = BookiiBookiiTheme.colors.uiMain,
+                    maxLines = 1,
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(220.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                RegionItem(
+                    text = NATIONWIDE,
+                    selected = selectedRegion == NATIONWIDE,
+                    onClick = { selectedRegion = NATIONWIDE },
+                )
+                cities.forEach { city ->
+                    RegionItem(
+                        text = city.name,
+                        selected = selectedRegion == city.name,
+                        onClick = {
+                            selectedRegion = city.name
+                            selectedDistricts = setOf(ALL)
+                        },
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                if (currentCity == null) {
+                    BottomSheetChip(text = NATIONWIDE, selected = true, onClick = {})
+                } else {
+                    FlowRow(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                        maxItemsInEachRow = 4,
+                    ) {
+                        currentCity.districts.forEach { district ->
+                            BottomSheetChip(
+                                text = district,
+                                selected = district in selectedDistricts,
+                                onClick = {
+                                    selectedDistricts = toggleDistrict(selectedDistricts, district)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            BottomSheetTwoBtnShort(
+                text = "취소",
+                style = BottomSheetBtnStyle.White,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+            BottomSheetTwoBtnShort(
+                text = "적용",
+                style = BottomSheetBtnStyle.Dark,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+// 좌측 지역 목록 아이템. 우측 라인 구분선 덧칠.
+@Composable
+private fun RegionItem(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val lineColor = if (selected) {
+        BookiiBookiiTheme.colors.uiMain
+    } else {
+        BookiiBookiiTheme.colors.grey200
+    }
+    Box(
+        modifier = modifier
+            .clickable(onClick = onClick)
+            .drawBehind {
+                val x = size.width
+                drawLine(
+                    color = lineColor,
+                    start = Offset(x, 0f),
+                    end = Offset(x, size.height),
+                    strokeWidth = 1.dp.toPx(),
+                )
+            }
+            .padding(start = 4.dp, end = 28.dp, top = 12.dp, bottom = 12.dp),
+    ) {
+        Text(
+            text = text,
+            style = if (selected) {
+                BookiiBookiiTheme.typography.medium16
+            } else {
+                BookiiBookiiTheme.typography.regular16
+            },
+            color = if (selected) {
+                BookiiBookiiTheme.colors.uiMain
+            } else {
+                BookiiBookiiTheme.colors.grey900
+            },
+            maxLines = 1,
+        )
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun RegionBottomSheetPreview() {
+    BookiiPreview {
+        RegionBottomSheet()
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/RegionBottomSheet.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/RegionBottomSheet.kt
@@ -175,9 +175,9 @@ fun RegionBottomSheet(
                     BottomSheetChip(text = NATIONWIDE, selected = true, onClick = {})
                 } else {
                     FlowRow(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
+                        modifier = Modifier.fillMaxWidth(0.9f),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                         maxItemsInEachRow = 4,
                     ) {
                         currentCity.districts.forEach { district ->

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Buttons.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Buttons.kt
@@ -3,8 +3,11 @@ package com.bookiibookii.bookiibookii.ui.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -70,10 +74,94 @@ fun SearchInputButton(
     }
 }
 
+enum class BottomSheetBtnStyle { White, Dark, Orange, Grey }
+
+@Composable
+fun BottomSheetTwoBtnShort(
+    text: String,
+    style: BottomSheetBtnStyle,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = BookiiBookiiTheme.shape.round16
+    val containerColor: Color
+    val contentColor: Color
+    val borderColor: Color?
+    when (style) {
+        BottomSheetBtnStyle.White -> {
+            containerColor = BookiiBookiiTheme.colors.white
+            contentColor = BookiiBookiiTheme.colors.grey900
+            borderColor = BookiiBookiiTheme.colors.grey200
+        }
+        BottomSheetBtnStyle.Dark -> {
+            containerColor = BookiiBookiiTheme.colors.grey900
+            contentColor = BookiiBookiiTheme.colors.white
+            borderColor = null
+        }
+        BottomSheetBtnStyle.Orange -> {
+            containerColor = BookiiBookiiTheme.colors.uiMain
+            contentColor = BookiiBookiiTheme.colors.white
+            borderColor = null
+        }
+        BottomSheetBtnStyle.Grey -> {
+            containerColor = BookiiBookiiTheme.colors.grey200
+            contentColor = BookiiBookiiTheme.colors.grey500
+            borderColor = null
+        }
+    }
+    Box(
+        modifier = modifier
+            .height(56.dp)
+            .clip(shape)
+            .background(containerColor)
+            .then(
+                if (borderColor != null) {
+                    Modifier.border(width = 1.dp, color = borderColor, shape = shape)
+                } else {
+                    Modifier
+                },
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium16,
+            color = contentColor,
+            maxLines = 1,
+        )
+    }
+}
+
 @Preview
 @Composable
 private fun SearchInputButtonPreview() {
     BookiiPreview {
         SearchInputButton(onClick = {})
+    }
+}
+
+@Preview
+@Composable
+private fun BottomSheetTwoBtnShortPreview() {
+    BookiiPreview {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            BottomSheetTwoBtnShort(
+                text = "취소",
+                style = BottomSheetBtnStyle.White,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+            BottomSheetTwoBtnShort(
+                text = "적용",
+                style = BottomSheetBtnStyle.Dark,
+                onClick = {},
+                modifier = Modifier.weight(1f),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Buttons.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Buttons.kt
@@ -1,32 +1,79 @@
 package com.bookiibookii.bookiibookii.ui.component
 
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
-// 임시로 만들어둔 거임 수정 필요
 @Composable
-fun BookiiPrimaryButton(
-    text: String,
+fun SearchInputButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    enabled: Boolean = true,
+    hint: String = "그룹명, 도서명, 저자로 검색",
 ) {
-    Button(
-        onClick = onClick,
-        enabled = enabled,
-        shape = BookiiBookiiTheme.shape.round20,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = BookiiBookiiTheme.colors.uiMain,
-            contentColor = BookiiBookiiTheme.colors.white,
-        ),
-        modifier = modifier.height(52.dp),
+    val shape = RoundedCornerShape(
+        topStart = 20.dp,
+        bottomStart = 20.dp,
+        topEnd = 30.dp,
+        bottomEnd = 30.dp,
+    )
+    Row(
+        modifier = modifier
+            .clip(shape)
+            .background(BookiiBookiiTheme.colors.white)
+            .border(width = 1.dp, color = BookiiBookiiTheme.colors.grey200, shape = shape)
+            .clickable(onClick = onClick)
+            .padding(start = 16.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text, style = BookiiBookiiTheme.typography.medium16)
+        Text(
+            text = hint,
+            style = BookiiBookiiTheme.typography.regular15,
+            color = BookiiBookiiTheme.colors.grey500,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Box(
+            modifier = Modifier
+                .size(44.dp)
+                .background(
+                    color = BookiiBookiiTheme.colors.grey300,
+                    shape = BookiiBookiiTheme.shape.round50,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_search),
+                contentDescription = null,
+                tint = BookiiBookiiTheme.colors.white,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun SearchInputButtonPreview() {
+    BookiiPreview {
+        SearchInputButton(onClick = {})
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Chip.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Chip.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -57,8 +59,45 @@ fun FilterChip(
     }
 }
 
-//@Composable
-//fun BottomSheetChip()
+@Composable
+fun BottomSheetChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = BookiiBookiiTheme.shape.round50
+    Box(
+        modifier = modifier
+            .height(46.dp)
+            .widthIn(min = 60.dp)
+            .clip(shape)
+            .background(
+                if (selected) BookiiBookiiTheme.colors.uiMain else BookiiBookiiTheme.colors.white,
+            )
+            .then(
+                if (selected) {
+                    Modifier
+                } else {
+                    Modifier.border(
+                        width = 1.dp,
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = shape,
+                    )
+                },
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium16,
+            color = if (selected) BookiiBookiiTheme.colors.white else BookiiBookiiTheme.colors.grey900,
+            maxLines = 1,
+        )
+    }
+}
 
 @Preview
 @Composable
@@ -67,6 +106,17 @@ private fun FilterChipPreview() {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             FilterChip(text = "교환 방식", selected = false, onClick = {})
             FilterChip(text = "분야별", selected = true, onClick = {})
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun BottomSheetChipPreview() {
+    BookiiPreview {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            BottomSheetChip(text = "전체", selected = true, onClick = {}, modifier = Modifier.width(120.dp))
+            BottomSheetChip(text = "직접 교환", selected = false, onClick = {})
         }
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Chip.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Chip.kt
@@ -1,0 +1,69 @@
+package com.bookiibookii.bookiibookii.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+@Composable
+fun FilterChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = BookiiBookiiTheme.shape.round26
+    Box(
+        modifier = modifier
+            .height(40.dp)
+            .clip(shape)
+            .background(
+                if (selected) BookiiBookiiTheme.colors.grey900 else BookiiBookiiTheme.colors.white,
+            )
+            .then(
+                if (selected) {
+                    Modifier
+                } else {
+                    Modifier.border(
+                        width = 1.dp,
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = shape,
+                    )
+                },
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.regular14,
+            color = if (selected) BookiiBookiiTheme.colors.white else BookiiBookiiTheme.colors.grey900,
+            maxLines = 1,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FilterChipPreview() {
+    BookiiPreview {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(text = "교환 방식", selected = false, onClick = {})
+            FilterChip(text = "분야별", selected = true, onClick = {})
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Chip.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/Chip.kt
@@ -57,6 +57,9 @@ fun FilterChip(
     }
 }
 
+//@Composable
+//fun BottomSheetChip()
+
 @Preview
 @Composable
 private fun FilterChipPreview() {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/theme/Shape.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/theme/Shape.kt
@@ -12,6 +12,7 @@ data class BookiiShape(
     val round8: Shape,
     val round16: Shape,
     val round20: Shape,
+    val round26: Shape,
     val round50: Shape,
 )
 
@@ -20,6 +21,7 @@ val bookiiShape = BookiiShape(
     round8 = RoundedCornerShape(8.dp),
     round16 = RoundedCornerShape(16.dp),
     round20 = RoundedCornerShape(20.dp),
+    round26 = RoundedCornerShape(26.dp),
     round50 = RoundedCornerShape(50.dp),
 )
 


### PR DESCRIPTION
# 📌 Pull Request Title
> - ui: 그룹 검색 화면 제작 (#285)

---

# ✨ 작업 내용 (What)
> - 교환 방식 바텀시트
<img width="372" height="223" alt="image" src="https://github.com/user-attachments/assets/56997667-f076-4709-88a1-429d6bb172c5" />

> - 지역 바텀시트 
<img width="273" height="227" alt="image" src="https://github.com/user-attachments/assets/0f0c83e2-56e6-42f9-87eb-21b937dcaa1b" />

> - 장르 바텀시트
<img width="219" height="181" alt="image" src="https://github.com/user-attachments/assets/6df155df-e08b-4e8a-a6e9-93812de223d2" />

---

# 💡추가 사항
> 공통 모듈: BottomSheetTwoBtnShort, FilterChip, BottomSheetChip 제작해둠

---

# 🔗 관련 이슈 (Optional)
- close #285
