### PR TITLE
feat: 그룹 생성 화면 vm 연결 (#289)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -135,6 +135,7 @@ dependencies {
     implementation("androidx.compose.material:material-icons-core")
     implementation("androidx.activity:activity-compose:1.9.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.0")
     implementation("androidx.navigation:navigation-compose:2.8.5")
     debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/GroupCreate.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/GroupCreate.kt
@@ -4,16 +4,19 @@ import com.google.gson.annotations.SerializedName
 
 data class GroupCreateRequest(
     @SerializedName("isbn13") val isbn13: String,
-    @SerializedName("maxCapacity") val maxCapacity: Int,
-    @SerializedName("startDate") val startDate: String,
-    @SerializedName("readingPeriod") val readingPeriod: Int,
-    @SerializedName("groupComment") val groupComment: String,
-    @SerializedName("customTag") val customTag: String,
-    @SerializedName("groupType") val groupType: String,
-    @SerializedName("tradeType") val tradeType: String,
+    @SerializedName("groupName") val groupName: String,
+    @SerializedName("tradeType") val tradeType: String,         // DIRECT / DELIVERY
     @SerializedName("preferRegion") val preferRegion: String,
-    @SerializedName("meetPlace") val meetPlace: String,
-    @SerializedName("tags") val tags: List<GroupTagRequest>
+    @SerializedName("readingPeriod") val readingPeriod: Int,    // 3, 7, 14, 21, 28
+    @SerializedName("groupComment") val groupComment: String?,  // 선택, 최대 500자
+    @SerializedName("rules") val rules: List<GroupRuleRequest>  // 1~5개
+)
+
+data class GroupRuleRequest(
+    // MEMO / POSTIT / PHOTO / ALL_ROUNDER / CUSTOM
+    @SerializedName("tag") val tag: String,
+    // CUSTOM 일 때만 텍스트, 프리셋 태그는 null
+    @SerializedName("content") val content: String?
 )
 
 data class GroupCreateResponse(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/ExchangeType.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/ExchangeType.kt
@@ -1,0 +1,4 @@
+package com.bookiibookii.bookiibookii.group.model
+
+// 교환 유형
+enum class ExchangeType { DELIVERY, DIRECT }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupEditorUiState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupEditorUiState.kt
@@ -1,0 +1,29 @@
+package com.bookiibookii.bookiibookii.group.model
+
+// 그룹 생성/수정 화면 UI 상태
+data class GroupEditorUiState(
+    val isbn13: String? = null,
+    val groupName: String = "",
+    val tradeType: ExchangeType? = null,
+    val preferRegion: String? = null,      // DIRECT/DELIVERY
+    val readingPeriodIndex: Int = 0,
+    val groupComment: String = "",         // 선택, 최대 500자
+    val ruleStyle: ReadingStyle? = null,   // 프리셋 1개 (드롭다운)
+    val customRules: List<String> = emptyList(),  // CUSTOM 항목, 최대 4개
+) {
+    val readingPeriod: Int get() = PERIODS[readingPeriodIndex]
+
+    val canSubmit: Boolean
+        get() = isbn13 != null &&
+            groupName.isNotBlank() &&
+            tradeType != null &&
+            !preferRegion.isNullOrBlank() &&
+            groupComment.length <= 500 &&
+            ruleStyle != null &&
+            (1 + customRules.count { it.isNotBlank() }) in 1..5
+
+    companion object {
+        val PERIODS = listOf(3, 7, 14, 21, 28)
+        const val MAX_CUSTOM_RULES = 4
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/ReadingStyle.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/ReadingStyle.kt
@@ -1,0 +1,15 @@
+package com.bookiibookii.bookiibookii.group.model
+
+import com.bookiibookii.bookiibookii.R
+
+// 그룹 규칙 프리셋
+enum class ReadingStyle(
+    val label: String,
+    val iconRes: Int,
+    val apiTag: String,
+) {
+    COMMENT("책에 직접 코멘트를 남겨요!", R.drawable.ic_edit, "MEMO"),
+    POSTIT("직접 메모 대신 포스트잇이나 인덱스를 활용해요!", R.drawable.ic_bookmark, "POSTIT"),
+    PHOTO("직접 메모 대신 사진으로 기록해요!", R.drawable.ic_camera, "PHOTO"),
+    ANY("어떤 방식이든 좋아요!", R.drawable.ic_book, "ALL_ROUNDER"),
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/editor/GroupEditorScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/editor/GroupEditorScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
@@ -26,6 +27,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -40,14 +42,53 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.group.model.ExchangeType
+import com.bookiibookii.bookiibookii.group.model.GroupEditorUiState
+import com.bookiibookii.bookiibookii.group.model.ReadingStyle
+import com.bookiibookii.bookiibookii.group.vm.GroupEditorViewModel
 import com.bookiibookii.bookiibookii.ui.component.FooterButton
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
-// 그룹 생성/수정 화면
+// 그룹 생성/수정 화면 (stateful: VM 주입·상태 수집)
 @Composable
-fun GroupEditorScreen() {
+fun GroupEditorRoute(
+    viewModel: GroupEditorViewModel = viewModel(),
+) {
+    val uiState by viewModel.state.collectAsStateWithLifecycle()
+    GroupEditorScreen(
+        uiState = uiState,
+        onGroupNameChange = viewModel::onGroupNameChange,
+        onTradeTypeSelect = viewModel::onTradeTypeSelect,
+        onReadingPeriodSelect = viewModel::onReadingPeriodSelect,
+        onRuleStyleSelect = viewModel::onRuleStyleSelect,
+        onGroupCommentChange = viewModel::onGroupCommentChange,
+        onAddCustomRule = viewModel::onAddCustomRule,
+        onCustomRuleChange = viewModel::onCustomRuleChange,
+        onRemoveCustomRule = viewModel::onRemoveCustomRule,
+        onBack = {},    // 후속: 네비게이션
+        onSubmit = {},  // 후속: 제출
+    )
+}
+
+// 그룹 생성/수정 화면 (stateless: 상태·콜백을 파라미터로 받음)
+@Composable
+fun GroupEditorScreen(
+    uiState: GroupEditorUiState,
+    onGroupNameChange: (String) -> Unit,
+    onTradeTypeSelect: (ExchangeType) -> Unit,
+    onReadingPeriodSelect: (Int) -> Unit,
+    onRuleStyleSelect: (ReadingStyle) -> Unit,
+    onGroupCommentChange: (String) -> Unit,
+    onAddCustomRule: () -> Unit,
+    onCustomRuleChange: (Int, String) -> Unit,
+    onRemoveCustomRule: (Int) -> Unit,
+    onBack: () -> Unit,
+    onSubmit: () -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -55,7 +96,7 @@ fun GroupEditorScreen() {
     ) {
         GroupEditorHeader(
             title = "그룹 만들기",
-            onBack = {},
+            onBack = onBack,
         )
 
         Column(
@@ -71,16 +112,35 @@ fun GroupEditorScreen() {
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 BookSearchSection()
-                GroupNameSection()
+                GroupNameSection(
+                    value = uiState.groupName,
+                    onValueChange = onGroupNameChange,
+                )
             }
             SectionDivider()
-            ExchangeTypeSection()
+            ExchangeTypeSection(
+                selected = uiState.tradeType,
+                onSelect = onTradeTypeSelect,
+            )
             SectionDivider()
-            ReadingPeriodSection()
+            ReadingPeriodSection(
+                selectedIndex = uiState.readingPeriodIndex,
+                onSelect = onReadingPeriodSelect,
+            )
             SectionDivider()
-            GroupRuleSection()
+            GroupRuleSection(
+                selectedRule = uiState.ruleStyle,
+                onRuleSelect = onRuleStyleSelect,
+                customRules = uiState.customRules,
+                onAddCustomRule = onAddCustomRule,
+                onCustomRuleChange = onCustomRuleChange,
+                onRemoveCustomRule = onRemoveCustomRule,
+            )
             SectionDivider()
-            GroupIntroSection()
+            GroupIntroSection(
+                value = uiState.groupComment,
+                onValueChange = onGroupCommentChange,
+            )
         }
 
         Box(
@@ -91,7 +151,8 @@ fun GroupEditorScreen() {
         ) {
             FooterButton(
                 text = "그룹 만들기",
-                onClick = {},
+                onClick = onSubmit,
+                enabled = uiState.canSubmit,
             )
         }
     }
@@ -201,10 +262,20 @@ private fun BookSearchSection() {
 
 // 그룹명 섹션
 @Composable
-private fun GroupNameSection() {
+private fun GroupNameSection(
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
     Column {
         FieldLabel(text = "그룹명", required = true)
-        Row(
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            textStyle = BookiiBookiiTheme.typography.regular16.copy(
+                color = BookiiBookiiTheme.colors.grey900,
+            ),
+            cursorBrush = SolidColor(BookiiBookiiTheme.colors.uiMain),
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(BookiiBookiiTheme.shape.round16)
@@ -215,24 +286,28 @@ private fun GroupNameSection() {
                     shape = BookiiBookiiTheme.shape.round16,
                 )
                 .padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = "그룹명을 입력해주세요",
-                style = BookiiBookiiTheme.typography.regular16,
-                color = BookiiBookiiTheme.colors.grey500,
-            )
-        }
+            decorationBox = { innerTextField ->
+                Box {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = "그룹명을 입력해주세요",
+                            style = BookiiBookiiTheme.typography.regular16,
+                            color = BookiiBookiiTheme.colors.grey500,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
     }
 }
 
-private enum class ExchangeType { DELIVERY, DIRECT }
-
 // 교환 유형 섹션. 단일 선택
 @Composable
-private fun ExchangeTypeSection() {
-    var selected by remember { mutableStateOf<ExchangeType?>(null) }
+private fun ExchangeTypeSection(
+    selected: ExchangeType?,
+    onSelect: (ExchangeType) -> Unit,
+) {
     Column {
         FieldLabel(text = "교환 유형", required = true)
         Row(
@@ -243,14 +318,14 @@ private fun ExchangeTypeSection() {
                 title = "택배 교환",
                 description = "책을 택배로 교환해요",
                 selected = selected == ExchangeType.DELIVERY,
-                onClick = { selected = ExchangeType.DELIVERY },
+                onClick = { onSelect(ExchangeType.DELIVERY) },
                 modifier = Modifier.weight(1f),
             )
             ExchangeTypeCard(
                 title = "직접 교환",
                 description = "책을 직접 만나서 교환해요",
                 selected = selected == ExchangeType.DIRECT,
-                onClick = { selected = ExchangeType.DIRECT },
+                onClick = { onSelect(ExchangeType.DIRECT) },
                 modifier = Modifier.weight(1f),
             )
         }
@@ -312,9 +387,11 @@ private fun ExchangeTypeCard(
 
 // 예상 독서 기간 섹션
 @Composable
-private fun ReadingPeriodSection() {
-    val periods = listOf(3, 7, 14, 21, 28)
-    var selectedIndex by remember { mutableStateOf(0) }
+private fun ReadingPeriodSection(
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit,
+) {
+    val periods = GroupEditorUiState.PERIODS
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Row(
             modifier = Modifier.padding(bottom = 8.dp),
@@ -339,7 +416,7 @@ private fun ReadingPeriodSection() {
             ReadingPeriodTrack(
                 count = periods.size,
                 selectedIndex = selectedIndex,
-                onSelect = { selectedIndex = it },
+                onSelect = onSelect,
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -359,7 +436,7 @@ private fun ReadingPeriodSection() {
                         } else {
                             BookiiBookiiTheme.colors.grey400
                         },
-                        modifier = Modifier.clickable { selectedIndex = index },
+                        modifier = Modifier.clickable { onSelect(index) },
                     )
                 }
             }
@@ -439,19 +516,17 @@ private fun ReadingPeriodTrack(
     }
 }
 
-// 그룹 규칙 옵션
-private enum class ReadingStyle(val label: String, val iconRes: Int) {
-    COMMENT("책에 직접 코멘트를 남겨요!", R.drawable.ic_edit),
-    POSTIT("직접 메모 대신 포스트잇이나 인덱스를 활용해요!", R.drawable.ic_bookmark),
-    PHOTO("직접 메모 대신 사진으로 기록해요!", R.drawable.ic_camera),
-    ANY("어떤 방식이든 좋아요!", R.drawable.ic_book),
-}
-
 // 그룹 규칙 섹션
 @Composable
-private fun GroupRuleSection() {
+private fun GroupRuleSection(
+    selectedRule: ReadingStyle?,
+    onRuleSelect: (ReadingStyle) -> Unit,
+    customRules: List<String>,
+    onAddCustomRule: () -> Unit,
+    onCustomRuleChange: (Int, String) -> Unit,
+    onRemoveCustomRule: (Int) -> Unit,
+) {
     var expanded by remember { mutableStateOf(false) }
-    var selectedRule by remember { mutableStateOf<ReadingStyle?>(null) }
     var fieldSize by remember { mutableStateOf(IntSize.Zero) }
     val listShape = BookiiBookiiTheme.shape.round24
     val density = LocalDensity.current
@@ -527,7 +602,7 @@ private fun GroupRuleSection() {
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .clickable {
-                                        selectedRule = style
+                                        onRuleSelect(style)
                                         expanded = false
                                     }
                                     .padding(vertical = 12.dp),
@@ -567,34 +642,43 @@ private fun GroupRuleSection() {
                 }
             }
         }
-        // 규칙 추가 버튼
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(56.dp)
-                .clip(BookiiBookiiTheme.shape.round20)
-                .background(BookiiBookiiTheme.colors.grey100)
-                .border(
-                    width = 1.dp,
-                    color = BookiiBookiiTheme.colors.grey200,
-                    shape = BookiiBookiiTheme.shape.round20,
+        customRules.forEachIndexed { index, rule ->
+            CustomRuleRow(
+                value = rule,
+                onValueChange = { onCustomRuleChange(index, it) },
+                onRemove = { onRemoveCustomRule(index) },
+            )
+        }
+        // 규칙 추가 버튼 (커스텀 규칙 4개면 숨김)
+        if (customRules.size < GroupEditorUiState.MAX_CUSTOM_RULES) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .clip(BookiiBookiiTheme.shape.round20)
+                    .background(BookiiBookiiTheme.colors.grey100)
+                    .border(
+                        width = 1.dp,
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = BookiiBookiiTheme.shape.round20,
+                    )
+                    .clickable { onAddCustomRule() }
+                    .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_plus),
+                    contentDescription = null,
+                    tint = BookiiBookiiTheme.colors.grey600,
+                    modifier = Modifier.size(20.dp),
                 )
-                .clickable { }
-                .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_plus),
-                contentDescription = null,
-                tint = BookiiBookiiTheme.colors.grey600,
-                modifier = Modifier.size(20.dp),
-            )
-            Text(
-                text = "규칙 추가",
-                style = BookiiBookiiTheme.typography.regular16,
-                color = BookiiBookiiTheme.colors.grey600,
-            )
+                Text(
+                    text = "규칙 추가",
+                    style = BookiiBookiiTheme.typography.regular16,
+                    color = BookiiBookiiTheme.colors.grey600,
+                )
+            }
         }
         Text(
             text = "최소 1개, 최대 5개까지 입력 가능합니다",
@@ -604,12 +688,76 @@ private fun GroupRuleSection() {
     }
 }
 
+// 커스텀 규칙 입력 행
+@Composable
+private fun CustomRuleRow(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onRemove: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .clip(BookiiBookiiTheme.shape.round20)
+            .background(BookiiBookiiTheme.colors.white)
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round20,
+            )
+            .padding(start = 20.dp, end = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            singleLine = true,
+            textStyle = BookiiBookiiTheme.typography.regular16.copy(
+                color = BookiiBookiiTheme.colors.grey900,
+            ),
+            cursorBrush = SolidColor(BookiiBookiiTheme.colors.uiMain),
+            modifier = Modifier.weight(1f),
+            decorationBox = { innerTextField ->
+                Box {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = "독서 스타일을 입력해주세요",
+                            style = BookiiBookiiTheme.typography.regular16,
+                            color = BookiiBookiiTheme.colors.grey400,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
+        Icon(
+            painter = painterResource(R.drawable.ic_x),
+            contentDescription = "규칙 삭제",
+            tint = BookiiBookiiTheme.colors.grey500,
+            modifier = Modifier
+                .size(24.dp)
+                .clickable { onRemove() },
+        )
+    }
+}
+
 // 그룹 소개 섹션
 @Composable
-private fun GroupIntroSection() {
+private fun GroupIntroSection(
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
     Column {
         FieldLabel(text = "그룹 소개")
-        Box(
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = BookiiBookiiTheme.typography.regular16.copy(
+                color = BookiiBookiiTheme.colors.grey900,
+            ),
+            cursorBrush = SolidColor(BookiiBookiiTheme.colors.uiMain),
             modifier = Modifier
                 .fillMaxWidth()
                 .height(128.dp)
@@ -621,14 +769,22 @@ private fun GroupIntroSection() {
                     shape = BookiiBookiiTheme.shape.round20,
                 )
                 .padding(20.dp),
-            contentAlignment = Alignment.TopStart,
-        ) {
-            Text(
-                text = "게스트가 꼭 지켜야 할 규칙을 적어주세요.",
-                style = BookiiBookiiTheme.typography.regular16,
-                color = BookiiBookiiTheme.colors.grey500,
-            )
-        }
+            decorationBox = { innerTextField ->
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.TopStart,
+                ) {
+                    if (value.isEmpty()) {
+                        Text(
+                            text = "게스트가 꼭 지켜야 할 규칙을 적어주세요.",
+                            style = BookiiBookiiTheme.typography.regular16,
+                            color = BookiiBookiiTheme.colors.grey500,
+                        )
+                    }
+                    innerTextField()
+                }
+            },
+        )
     }
 }
 
@@ -647,6 +803,18 @@ private fun SectionDivider() {
 @Composable
 private fun GroupEditorScreenPreview() {
     BookiiPreview {
-        GroupEditorScreen()
+        GroupEditorScreen(
+            uiState = GroupEditorUiState(),
+            onGroupNameChange = {},
+            onTradeTypeSelect = {},
+            onReadingPeriodSelect = {},
+            onRuleStyleSelect = {},
+            onGroupCommentChange = {},
+            onAddCustomRule = {},
+            onCustomRuleChange = { _, _ -> },
+            onRemoveCustomRule = {},
+            onBack = {},
+            onSubmit = {},
+        )
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupEditorViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupEditorViewModel.kt
@@ -1,0 +1,46 @@
+package com.bookiibookii.bookiibookii.group.vm
+
+import androidx.lifecycle.ViewModel
+import com.bookiibookii.bookiibookii.group.model.ExchangeType
+import com.bookiibookii.bookiibookii.group.model.GroupEditorUiState
+import com.bookiibookii.bookiibookii.group.model.ReadingStyle
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+class GroupEditorViewModel : ViewModel() {
+
+    private val _state = MutableStateFlow(GroupEditorUiState())
+    val state: StateFlow<GroupEditorUiState> = _state
+
+    fun onGroupNameChange(value: String) =
+        _state.update { it.copy(groupName = value) }
+
+    fun onTradeTypeSelect(type: ExchangeType) =
+        _state.update { it.copy(tradeType = type) }
+
+    fun onReadingPeriodSelect(index: Int) =
+        _state.update { it.copy(readingPeriodIndex = index) }
+
+    fun onRuleStyleSelect(style: ReadingStyle) =
+        _state.update { it.copy(ruleStyle = style) }
+
+    fun onGroupCommentChange(value: String) =
+        _state.update { it.copy(groupComment = value) }
+
+    fun onAddCustomRule() = _state.update {
+        if (it.customRules.size >= GroupEditorUiState.MAX_CUSTOM_RULES) it
+        else it.copy(customRules = it.customRules + "")
+    }
+
+    fun onCustomRuleChange(index: Int, value: String) = _state.update {
+        it.copy(
+            customRules = it.customRules.toMutableList()
+                .apply { if (index in indices) this[index] = value },
+        )
+    }
+
+    fun onRemoveCustomRule(index: Int) = _state.update {
+        it.copy(customRules = it.customRules.filterIndexed { i, _ -> i != index })
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request Title
> - feat: 그룹 생성 화면 vm 연결 (#289)

---

# ✨ 작업 내용 (What)
> - 그룹 생성, 수정 화면 관련 viewModel을 제작했습니다

---

# 💡추가 사항
> - 도서 검색(알라딘 API) UI → isbn13
> - 지역 선택 UI → preferRegion
> - 그룹 생성 제출 로직
> - 네비게이션 그래프 연결(groupId로 생성 / 수정 분기)

---

# 🔗 관련 이슈 (Optional)
- close #289
