### PR TITLE
ui: 트래커 택배교환 공용 모달 (#302)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDeliveryDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDeliveryDetailScreen.kt
@@ -1,1 +1,155 @@
 package com.bookiibookii.bookiibookii.tracker.ui.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+@Composable
+fun TrackerDeliveryDetailScreen(
+    onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onMoreClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(BookiiBookiiTheme.colors.uiBg),
+    ) {
+        TrackerDetailHeader(
+            onBackClick = onBackClick,
+            onMessageClick = onMessageClick,
+            onMoreClick = onMoreClick,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            // TODO B1~B3: 트래커 상세 카드 (그룹 정보 + 두 트래커 + 액션 버튼)
+            // TODO C: TrackerStepList
+        }
+    }
+}
+
+@Composable
+private fun TrackerDetailHeader(
+    onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onMoreClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(BookiiBookiiTheme.colors.white),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(68.dp)
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            IconCircleButton(
+                iconRes = R.drawable.ic_back,
+                onClick = onBackClick,
+            )
+            Text(
+                text = "교환 현황",
+                style = BookiiBookiiTheme.typography.medium20,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconCircleButton(
+                    iconRes = R.drawable.ic_message,
+                    onClick = onMessageClick,
+                )
+                IconCircleButton(
+                    iconRes = R.drawable.ic_meetball,
+                    onClick = onMoreClick,
+                )
+            }
+        }
+        HorizontalDivider(
+            thickness = 1.dp,
+            color = BookiiBookiiTheme.colors.grey200,
+        )
+    }
+}
+
+@Composable
+private fun IconCircleButton(
+    iconRes: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(id = iconRes),
+            contentDescription = null,
+            modifier = Modifier.size(32.dp),
+            tint = Color.Unspecified,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TrackerDetailHeaderPreview() {
+    BookiiPreview {
+        TrackerDetailHeader(
+            onBackClick = {},
+            onMessageClick = {},
+            onMoreClick = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, heightDp = 800)
+@Composable
+private fun TrackerDeliveryDetailScreenPreview() {
+    BookiiPreview {
+        TrackerDeliveryDetailScreen(
+            onBackClick = {},
+            onMessageClick = {},
+            onMoreClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDeliveryDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDeliveryDetailScreen.kt
@@ -1,155 +1,109 @@
 package com.bookiibookii.bookiibookii.tracker.ui.detail
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.tracker.model.TrackerProfileItem
+import com.bookiibookii.bookiibookii.tracker.ui.detail.component.TrackerDetailContent
+import com.bookiibookii.bookiibookii.tracker.ui.detail.component.TrackerStep
+import com.bookiibookii.bookiibookii.tracker.ui.detail.component.TrackerStepStatus
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
-import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
 @Composable
 fun TrackerDeliveryDetailScreen(
+    groupName: String,
+    dDay: String,
+    bookTitle: String,
+    statusLabel: String,
+    currentStepLabel: String,
+    myProfile: TrackerProfileItem,
+    partnerProfile: TrackerProfileItem,
+    secondaryActionLabel: String,
+    primaryActionLabel: String,
+    steps: List<TrackerStep>,
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
     onMoreClick: () -> Unit,
+    onSecondaryActionClick: () -> Unit,
+    onPrimaryActionClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(BookiiBookiiTheme.colors.uiBg),
-    ) {
-        TrackerDetailHeader(
-            onBackClick = onBackClick,
-            onMessageClick = onMessageClick,
-            onMoreClick = onMoreClick,
-        )
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            // TODO B1~B3: 트래커 상세 카드 (그룹 정보 + 두 트래커 + 액션 버튼)
-            // TODO C: TrackerStepList
-        }
-    }
+    TrackerDetailContent(
+        groupName = groupName,
+        dDay = dDay,
+        bookTitle = bookTitle,
+        statusLabel = statusLabel,
+        currentStepLabel = currentStepLabel,
+        myProfile = myProfile,
+        partnerProfile = partnerProfile,
+        exchangeLabel = "택배 교환",
+        secondaryActionLabel = secondaryActionLabel,
+        primaryActionLabel = primaryActionLabel,
+        steps = steps,
+        onBackClick = onBackClick,
+        onMessageClick = onMessageClick,
+        onMoreClick = onMoreClick,
+        onSecondaryActionClick = onSecondaryActionClick,
+        onPrimaryActionClick = onPrimaryActionClick,
+        modifier = modifier,
+    )
 }
 
-@Composable
-private fun TrackerDetailHeader(
-    onBackClick: () -> Unit,
-    onMessageClick: () -> Unit,
-    onMoreClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(BookiiBookiiTheme.colors.white),
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(68.dp)
-                .padding(horizontal = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            IconCircleButton(
-                iconRes = R.drawable.ic_back,
-                onClick = onBackClick,
-            )
-            Text(
-                text = "교환 현황",
-                style = BookiiBookiiTheme.typography.medium20,
-                color = BookiiBookiiTheme.colors.grey900,
-            )
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                IconCircleButton(
-                    iconRes = R.drawable.ic_message,
-                    onClick = onMessageClick,
-                )
-                IconCircleButton(
-                    iconRes = R.drawable.ic_meetball,
-                    onClick = onMoreClick,
-                )
-            }
-        }
-        HorizontalDivider(
-            thickness = 1.dp,
-            color = BookiiBookiiTheme.colors.grey200,
-        )
-    }
-}
-
-@Composable
-private fun IconCircleButton(
-    iconRes: Int,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .size(40.dp)
-            .clip(CircleShape)
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.Center,
-    ) {
-        Icon(
-            painter = painterResource(id = iconRes),
-            contentDescription = null,
-            modifier = Modifier.size(32.dp),
-            tint = Color.Unspecified,
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun TrackerDetailHeaderPreview() {
-    BookiiPreview {
-        TrackerDetailHeader(
-            onBackClick = {},
-            onMessageClick = {},
-            onMoreClick = {},
-        )
-    }
-}
-
-@Preview(showBackground = true, heightDp = 800)
+@Preview(showBackground = true, heightDp = 1000)
 @Composable
 private fun TrackerDeliveryDetailScreenPreview() {
     BookiiPreview {
         TrackerDeliveryDetailScreen(
+            groupName = "김영하 도장깨기 하실 분",
+            dDay = "D-2",
+            bookTitle = "살인자의 기억법",
+            statusLabel = "후기 작성",
+            currentStepLabel = "내 책 읽기",
+            myProfile = TrackerProfileItem(
+                nickname = "나",
+                bookTitle = "살인자의 기억법",
+                bookCoverUrl = null,
+                profileImageUrl = null,
+                progressPercent = 100,
+                isMine = true,
+            ),
+            partnerProfile = TrackerProfileItem(
+                nickname = "noshel",
+                bookTitle = "작별인사",
+                bookCoverUrl = null,
+                profileImageUrl = null,
+                progressPercent = 0,
+                isMine = false,
+            ),
+            secondaryActionLabel = "독서카드 작성",
+            primaryActionLabel = "책 후기 작성",
+            steps = listOf(
+                TrackerStep(
+                    title = "반납",
+                    description = "파트너에게 책을 돌려보내주세요",
+                    status = TrackerStepStatus.Pending,
+                ),
+                TrackerStep(
+                    title = "파트너 책 읽기",
+                    description = "작별인사를 읽고 진행률을 기록해주세요",
+                    status = TrackerStepStatus.InProgress(chipText = "D-2"),
+                ),
+                TrackerStep(
+                    title = "교환",
+                    description = "파트너와 책을 교환해주세요",
+                    status = TrackerStepStatus.Completed,
+                ),
+                TrackerStep(
+                    title = "살인자의 기억법 읽기",
+                    description = "독서카드를 작성하면 교환독서가 더 즐거워져요",
+                    status = TrackerStepStatus.Completed,
+                ),
+            ),
             onBackClick = {},
             onMessageClick = {},
             onMoreClick = {},
+            onSecondaryActionClick = {},
+            onPrimaryActionClick = {},
         )
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDirectDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDirectDetailScreen.kt
@@ -1,1 +1,109 @@
 package com.bookiibookii.bookiibookii.tracker.ui.detail
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.bookiibookii.bookiibookii.tracker.model.TrackerProfileItem
+import com.bookiibookii.bookiibookii.tracker.ui.detail.component.TrackerDetailContent
+import com.bookiibookii.bookiibookii.tracker.ui.detail.component.TrackerStep
+import com.bookiibookii.bookiibookii.tracker.ui.detail.component.TrackerStepStatus
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+
+@Composable
+fun TrackerDirectDetailScreen(
+    groupName: String,
+    dDay: String,
+    bookTitle: String,
+    statusLabel: String,
+    currentStepLabel: String,
+    myProfile: TrackerProfileItem,
+    partnerProfile: TrackerProfileItem,
+    secondaryActionLabel: String,
+    primaryActionLabel: String,
+    steps: List<TrackerStep>,
+    onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onMoreClick: () -> Unit,
+    onSecondaryActionClick: () -> Unit,
+    onPrimaryActionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TrackerDetailContent(
+        groupName = groupName,
+        dDay = dDay,
+        bookTitle = bookTitle,
+        statusLabel = statusLabel,
+        currentStepLabel = currentStepLabel,
+        myProfile = myProfile,
+        partnerProfile = partnerProfile,
+        exchangeLabel = "직접 교환",
+        secondaryActionLabel = secondaryActionLabel,
+        primaryActionLabel = primaryActionLabel,
+        steps = steps,
+        onBackClick = onBackClick,
+        onMessageClick = onMessageClick,
+        onMoreClick = onMoreClick,
+        onSecondaryActionClick = onSecondaryActionClick,
+        onPrimaryActionClick = onPrimaryActionClick,
+        modifier = modifier,
+    )
+}
+
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+private fun TrackerDirectDetailScreenPreview() {
+    BookiiPreview {
+        TrackerDirectDetailScreen(
+            groupName = "김영하 도장깨기 하실 분",
+            dDay = "D-2",
+            bookTitle = "살인자의 기억법",
+            statusLabel = "후기 작성",
+            currentStepLabel = "내 책 읽기",
+            myProfile = TrackerProfileItem(
+                nickname = "나",
+                bookTitle = "살인자의 기억법",
+                bookCoverUrl = null,
+                profileImageUrl = null,
+                progressPercent = 100,
+                isMine = true,
+            ),
+            partnerProfile = TrackerProfileItem(
+                nickname = "noshel",
+                bookTitle = "작별인사",
+                bookCoverUrl = null,
+                profileImageUrl = null,
+                progressPercent = 0,
+                isMine = false,
+            ),
+            secondaryActionLabel = "독서카드 작성",
+            primaryActionLabel = "책 후기 작성",
+            steps = listOf(
+                TrackerStep(
+                    title = "반납",
+                    description = "파트너에게 책을 돌려보내주세요",
+                    status = TrackerStepStatus.Pending,
+                ),
+                TrackerStep(
+                    title = "파트너 책 읽기",
+                    description = "작별인사를 읽고 진행률을 기록해주세요",
+                    status = TrackerStepStatus.InProgress(chipText = "D-2"),
+                ),
+                TrackerStep(
+                    title = "교환",
+                    description = "파트너와 책을 교환해주세요",
+                    status = TrackerStepStatus.Completed,
+                ),
+                TrackerStep(
+                    title = "살인자의 기억법 읽기",
+                    description = "독서카드를 작성하면 교환독서가 더 즐거워져요",
+                    status = TrackerStepStatus.Completed,
+                ),
+            ),
+            onBackClick = {},
+            onMessageClick = {},
+            onMoreClick = {},
+            onSecondaryActionClick = {},
+            onPrimaryActionClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerDetailContent.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerDetailContent.kt
@@ -1,0 +1,549 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.tracker.model.TrackerProfileItem
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
+import com.bookiibookii.bookiibookii.ui.component.BottomSheetTwoBtnShort
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+private val OuterCardPadding = 20.dp
+
+// 트래커 상세 본문 (택배/직접교환 공통)
+// 헤더 + 그룹 정보 카드 + 단계 리스트
+@Composable
+fun TrackerDetailContent(
+    groupName: String,
+    dDay: String,
+    bookTitle: String,
+    statusLabel: String,
+    currentStepLabel: String,
+    myProfile: TrackerProfileItem,
+    partnerProfile: TrackerProfileItem,
+    exchangeLabel: String,
+    secondaryActionLabel: String,
+    primaryActionLabel: String,
+    steps: List<TrackerStep>,
+    onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onMoreClick: () -> Unit,
+    onSecondaryActionClick: () -> Unit,
+    onPrimaryActionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(BookiiBookiiTheme.colors.uiBg),
+    ) {
+        TrackerDetailHeader(
+            onBackClick = onBackClick,
+            onMessageClick = onMessageClick,
+            onMoreClick = onMoreClick,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(BookiiBookiiTheme.colors.white)
+                    .padding(OuterCardPadding),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+            ) {
+                GroupInfoSection(
+                    groupName = groupName,
+                    dDay = dDay,
+                    bookTitle = bookTitle,
+                    statusLabel = statusLabel,
+                    currentStepLabel = currentStepLabel,
+                )
+                TwoProfileSection(
+                    myProfile = myProfile,
+                    partnerProfile = partnerProfile,
+                    exchangeLabel = exchangeLabel,
+                )
+                ActionButtonsRow(
+                    secondaryLabel = secondaryActionLabel,
+                    primaryLabel = primaryActionLabel,
+                    onSecondaryClick = onSecondaryActionClick,
+                    onPrimaryClick = onPrimaryActionClick,
+                )
+            }
+            TrackerStepList(
+                steps = steps,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrackerDetailHeader(
+    onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onMoreClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(BookiiBookiiTheme.colors.white),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(68.dp)
+                .padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            IconCircleButton(
+                iconRes = R.drawable.ic_back,
+                onClick = onBackClick,
+            )
+            Text(
+                text = "교환 현황",
+                style = BookiiBookiiTheme.typography.medium20,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconCircleButton(
+                    iconRes = R.drawable.ic_message,
+                    onClick = onMessageClick,
+                )
+                IconCircleButton(
+                    iconRes = R.drawable.ic_meetball,
+                    onClick = onMoreClick,
+                )
+            }
+        }
+        HorizontalDivider(
+            thickness = 1.dp,
+            color = BookiiBookiiTheme.colors.grey200,
+        )
+    }
+}
+
+@Composable
+private fun IconCircleButton(
+    iconRes: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(id = iconRes),
+            contentDescription = null,
+            modifier = Modifier.size(32.dp),
+            tint = Color.Unspecified,
+        )
+    }
+}
+
+@Composable
+private fun GroupInfoSection(
+    groupName: String,
+    dDay: String,
+    bookTitle: String,
+    statusLabel: String,
+    currentStepLabel: String,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = groupName,
+            style = BookiiBookiiTheme.typography.medium16,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    DDayChip(text = dDay)
+                    Text(
+                        text = "$bookTitle · $statusLabel",
+                        style = BookiiBookiiTheme.typography.regular16,
+                        color = BookiiBookiiTheme.colors.grey800,
+                    )
+                }
+                StatusProgressBar(currentStepLabel = currentStepLabel)
+            }
+            HorizontalDivider(
+                thickness = 0.8.dp,
+                color = BookiiBookiiTheme.colors.grey100,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DDayChip(text: String) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = BookiiBookiiTheme.colors.grey100,
+                shape = BookiiBookiiTheme.shape.round8,
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium11,
+            color = BookiiBookiiTheme.colors.grey700,
+        )
+    }
+}
+
+@Composable
+private fun StatusProgressBar(currentStepLabel: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .background(
+                    color = BookiiBookiiTheme.colors.uiMainPale,
+                    shape = BookiiBookiiTheme.shape.round8,
+                )
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+        ) {
+            Text(
+                text = currentStepLabel,
+                style = BookiiBookiiTheme.typography.regular10,
+                color = BookiiBookiiTheme.colors.uiMain,
+            )
+        }
+        repeat(3) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(BookiiBookiiTheme.colors.grey100),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TwoProfileSection(
+    myProfile: TrackerProfileItem,
+    partnerProfile: TrackerProfileItem,
+    exchangeLabel: String,
+) {
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            ProfileColumn(profile = myProfile, modifier = Modifier.weight(1f))
+            ProfileColumn(profile = partnerProfile, modifier = Modifier.weight(1f))
+        }
+        ExchangeConnector(
+            label = exchangeLabel,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 52.dp),
+        )
+    }
+}
+
+@Composable
+private fun ProfileColumn(
+    profile: TrackerProfileItem,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            BookCover(isMine = profile.isMine)
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = profile.nickname,
+                        style = BookiiBookiiTheme.typography.regular14,
+                        color = BookiiBookiiTheme.colors.grey700,
+                    )
+                    Text(
+                        text = profile.bookTitle,
+                        style = BookiiBookiiTheme.typography.medium16,
+                        color = BookiiBookiiTheme.colors.grey800,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    TrackerProgressBar(percent = profile.progressPercent)
+                    Text(
+                        text = "${profile.progressPercent}%",
+                        style = BookiiBookiiTheme.typography.regular14,
+                        color = BookiiBookiiTheme.colors.grey800,
+                    )
+                }
+            }
+        }
+        Box(
+            modifier = Modifier
+                .offset(x = 27.dp, y = 0.dp)
+                .size(44.dp),
+        ) {
+            Image(
+                painter = painterResource(R.drawable.profile_bg),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey500),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BookCover(isMine: Boolean) {
+    Box(
+        modifier = Modifier
+            .size(width = 80.dp, height = 104.dp)
+            .clip(BookiiBookiiTheme.shape.round8)
+            .background(BookiiBookiiTheme.colors.uiBg),
+        contentAlignment = Alignment.BottomEnd,
+    ) {
+        if (isMine) {
+            Box(
+                modifier = Modifier
+                    .padding(4.dp)
+                    .clip(BookiiBookiiTheme.shape.round4)
+                    .background(Color.White.copy(alpha = 0.75f))
+                    .padding(horizontal = 4.dp, vertical = 2.dp),
+            ) {
+                Text(
+                    text = "내 책",
+                    style = BookiiBookiiTheme.typography.regular10,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TrackerProgressBar(percent: Int) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(3.dp)
+                .background(BookiiBookiiTheme.colors.grey200),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(fraction = (percent / 100f).coerceIn(0f, 1f))
+                .height(3.dp)
+                .background(BookiiBookiiTheme.colors.grey800),
+        )
+    }
+}
+
+@Composable
+private fun ExchangeConnector(
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.width(113.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp),
+        ) {
+            val dash = 4.dp.toPx()
+            drawLine(
+                color = Color(0xFFC6C5C2),
+                start = Offset(0f, size.height / 2f),
+                end = Offset(size.width, size.height / 2f),
+                strokeWidth = 1.dp.toPx(),
+                pathEffect = PathEffect.dashPathEffect(floatArrayOf(dash, dash)),
+            )
+        }
+        Box(
+            modifier = Modifier
+                .background(
+                    color = BookiiBookiiTheme.colors.white,
+                    shape = BookiiBookiiTheme.shape.round8,
+                )
+                .border(
+                    width = 1.dp,
+                    color = BookiiBookiiTheme.colors.grey200,
+                    shape = BookiiBookiiTheme.shape.round8,
+                )
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        ) {
+            Text(
+                text = label,
+                style = BookiiBookiiTheme.typography.medium11,
+                color = BookiiBookiiTheme.colors.grey400,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionButtonsRow(
+    secondaryLabel: String,
+    primaryLabel: String,
+    onSecondaryClick: () -> Unit,
+    onPrimaryClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        BottomSheetTwoBtnShort(
+            text = secondaryLabel,
+            style = BottomSheetBtnStyle.White,
+            onClick = onSecondaryClick,
+            modifier = Modifier.weight(1f),
+        )
+        BottomSheetTwoBtnShort(
+            text = primaryLabel,
+            style = BottomSheetBtnStyle.Orange,
+            onClick = onPrimaryClick,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Preview(showBackground = true, heightDp = 1000)
+@Composable
+private fun TrackerDetailContentPreview() {
+    BookiiPreview {
+        TrackerDetailContent(
+            groupName = "김영하 도장깨기 하실 분",
+            dDay = "D-2",
+            bookTitle = "살인자의 기억법",
+            statusLabel = "후기 작성",
+            currentStepLabel = "내 책 읽기",
+            myProfile = TrackerProfileItem(
+                nickname = "나",
+                bookTitle = "살인자의 기억법",
+                bookCoverUrl = null,
+                profileImageUrl = null,
+                progressPercent = 100,
+                isMine = true,
+            ),
+            partnerProfile = TrackerProfileItem(
+                nickname = "noshel",
+                bookTitle = "작별인사",
+                bookCoverUrl = null,
+                profileImageUrl = null,
+                progressPercent = 0,
+                isMine = false,
+            ),
+            exchangeLabel = "택배 교환",
+            secondaryActionLabel = "독서카드 작성",
+            primaryActionLabel = "책 후기 작성",
+            steps = listOf(
+                TrackerStep(
+                    title = "반납",
+                    description = "파트너에게 책을 돌려보내주세요",
+                    status = TrackerStepStatus.Pending,
+                ),
+                TrackerStep(
+                    title = "파트너 책 읽기",
+                    description = "작별인사를 읽고 진행률을 기록해주세요",
+                    status = TrackerStepStatus.InProgress(chipText = "D-2"),
+                ),
+                TrackerStep(
+                    title = "교환",
+                    description = "파트너와 책을 교환해주세요",
+                    status = TrackerStepStatus.Completed,
+                ),
+                TrackerStep(
+                    title = "살인자의 기억법 읽기",
+                    description = "독서카드를 작성하면 교환독서가 더 즐거워져요",
+                    status = TrackerStepStatus.Completed,
+                ),
+            ),
+            onBackClick = {},
+            onMessageClick = {},
+            onMoreClick = {},
+            onSecondaryActionClick = {},
+            onPrimaryActionClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerMoreMenuDropdown.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerMoreMenuDropdown.kt
@@ -1,0 +1,128 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 트래커 상세 더보기 드롭다운 (택배/직접교환 공통)
+// 게스트일 때는 "독서 기간 수정" 항목이 표시되지 않음
+@Composable
+fun TrackerMoreMenuDropdown(
+    isHost: Boolean,
+    onEditPeriodClick: () -> Unit,
+    onGoToLibraryClick: () -> Unit,
+    onReportClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .width(IntrinsicSize.Max)
+            .shadow(elevation = 6.dp, shape = BookiiBookiiTheme.shape.round10)
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round10,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round10,
+            )
+            .padding(vertical = 4.dp),
+    ) {
+        if (isHost) {
+            MenuItem(
+                text = "독서 기간 수정",
+                iconRes = R.drawable.ic_edit,
+                onClick = onEditPeriodClick,
+            )
+        }
+        MenuItem(
+            text = "서재로 이동",
+            iconRes = R.drawable.ic_book,
+            onClick = onGoToLibraryClick,
+        )
+        MenuItem(
+            text = "신고",
+            iconRes = R.drawable.ic_report_32,
+            onClick = onReportClick,
+        )
+    }
+}
+
+@Composable
+private fun MenuItem(
+    text: String,
+    iconRes: Int,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium14,
+            color = BookiiBookiiTheme.colors.grey700,
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = null,
+            tint = BookiiBookiiTheme.colors.grey700,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Preview(widthDp = 200, showBackground = true)
+@Composable
+private fun TrackerMoreMenuDropdownHostPreview() {
+    BookiiPreview {
+        TrackerMoreMenuDropdown(
+            isHost = true,
+            onEditPeriodClick = {},
+            onGoToLibraryClick = {},
+            onReportClick = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Preview(widthDp = 200, showBackground = true)
+@Composable
+private fun TrackerMoreMenuDropdownGuestPreview() {
+    BookiiPreview {
+        TrackerMoreMenuDropdown(
+            isHost = false,
+            onEditPeriodClick = {},
+            onGoToLibraryClick = {},
+            onReportClick = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerReadingPeriodEditDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerReadingPeriodEditDialog.kt
@@ -255,14 +255,12 @@ private fun TrackerReadingPeriodEditDialogContent(
                 style = CardButtonStyle.White,
                 onClick = onDismiss,
                 modifier = Modifier.weight(1f),
-                height = 48.dp,
             )
             CardButton(
                 text = "수정",
                 style = if (selectedDate != null) CardButtonStyle.Main else CardButtonStyle.Grey,
                 onClick = {},
                 modifier = Modifier.weight(1f),
-                height = 48.dp,
             )
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerStepList.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerStepList.kt
@@ -1,0 +1,206 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 트래커 상세 단계 리스트 (택배/직접교환 공통)
+// 진행중인 단계가 맨 위, 완료된 단계가 아래로 쌓이는 구조
+sealed class TrackerStepStatus {
+    data object Pending : TrackerStepStatus()
+
+    // chipText는 외부 주입
+    data class InProgress(val chipText: String) : TrackerStepStatus()
+    data object Completed : TrackerStepStatus()
+}
+
+data class TrackerStep(
+    val title: String,
+    val description: String,
+    val status: TrackerStepStatus,
+)
+
+@Composable
+fun TrackerStepList(
+    steps: List<TrackerStep>,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round20,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        steps.forEachIndexed { index, step ->
+            TrackerStepItem(
+                step = step,
+                showDivider = index < steps.lastIndex,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrackerStepItem(
+    step: TrackerStep,
+    showDivider: Boolean,
+) {
+    val isCompleted = step.status is TrackerStepStatus.Completed
+    val titleStyle = if (isCompleted) {
+        BookiiBookiiTheme.typography.regular16
+    } else {
+        BookiiBookiiTheme.typography.medium16
+    }
+    val titleColor = if (isCompleted) {
+        BookiiBookiiTheme.colors.grey600
+    } else {
+        BookiiBookiiTheme.colors.grey900
+    }
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = step.title,
+                    style = titleStyle,
+                    color = titleColor,
+                )
+                StepChip(status = step.status)
+            }
+            Text(
+                text = step.description,
+                style = BookiiBookiiTheme.typography.regular14,
+                color = BookiiBookiiTheme.colors.grey500,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        if (showDivider) {
+            HorizontalDivider(
+                modifier = Modifier.padding(top = 16.dp),
+                thickness = 1.dp,
+                color = BookiiBookiiTheme.colors.grey100,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepChip(status: TrackerStepStatus) {
+    when (status) {
+        is TrackerStepStatus.InProgress -> {
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = BookiiBookiiTheme.colors.white,
+                        shape = BookiiBookiiTheme.shape.round8,
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = BookiiBookiiTheme.colors.uiMain150,
+                        shape = BookiiBookiiTheme.shape.round8,
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            ) {
+                Text(
+                    text = status.chipText,
+                    style = BookiiBookiiTheme.typography.regular11,
+                    color = BookiiBookiiTheme.colors.uiMain,
+                )
+            }
+        }
+        TrackerStepStatus.Pending -> {
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = BookiiBookiiTheme.colors.white,
+                        shape = BookiiBookiiTheme.shape.round8,
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = BookiiBookiiTheme.shape.round8,
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            ) {
+                Text(
+                    text = "예정",
+                    style = BookiiBookiiTheme.typography.regular11,
+                    color = BookiiBookiiTheme.colors.grey500,
+                )
+            }
+        }
+        TrackerStepStatus.Completed -> {
+            Box(
+                modifier = Modifier
+                    .background(
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = BookiiBookiiTheme.shape.round8,
+                    )
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+            ) {
+                Text(
+                    text = "완료",
+                    style = BookiiBookiiTheme.typography.regular11,
+                    color = BookiiBookiiTheme.colors.grey500,
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerStepListPreview() {
+    BookiiPreview {
+        TrackerStepList(
+            steps = listOf(
+                TrackerStep(
+                    title = "반납",
+                    description = "파트너에게 책을 돌려보내주세요",
+                    status = TrackerStepStatus.Pending,
+                ),
+                TrackerStep(
+                    title = "파트너 책 읽기",
+                    description = "작별인사를 읽고 진행률을 기록해주세요",
+                    status = TrackerStepStatus.InProgress(chipText = "D-2"),
+                ),
+                TrackerStep(
+                    title = "교환",
+                    description = "파트너와 책을 교환해주세요",
+                    status = TrackerStepStatus.Completed,
+                ),
+                TrackerStep(
+                    title = "살인자의 기억법 읽기",
+                    description = "독서카드를 작성하면 교환독서가 더 즐거워져요",
+                    status = TrackerStepStatus.Completed,
+                ),
+            ),
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryAddressEditDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryAddressEditDialog.kt
@@ -137,14 +137,12 @@ private fun TrackerDeliveryAddressEditDialogContent(
                 style = CardButtonStyle.White,
                 onClick = onDismiss,
                 modifier = Modifier.weight(1f),
-                height = 48.dp,
             )
             CardButton(
                 text = "확인",
                 style = CardButtonStyle.Main,
                 onClick = onConfirmClick,
                 modifier = Modifier.weight(1f),
-                height = 48.dp,
             )
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryAddressEditDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryAddressEditDialog.kt
@@ -1,0 +1,252 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.delivery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+private data class SavedAddress(val title: String, val address: String)
+
+private val DUMMY_ADDRESSES = listOf(
+    SavedAddress(title = "자취방", address = "서울 용산구 한강로2가 426"),
+    SavedAddress(title = "회사", address = "서울 강남구 테헤란로 123"),
+)
+
+// 택배 배송 정보 수정 다이얼로그 (택배교환 전용)
+@Composable
+fun TrackerDeliveryAddressEditDialog(
+    onDismiss: () -> Unit,
+    onConfirmClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDeliveryAddressEditDialogContent(
+            onDismiss = onDismiss,
+            onConfirmClick = onConfirmClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDeliveryAddressEditDialogContent(
+    onDismiss: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedIndex by remember { mutableIntStateOf(0) }
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "배송 정보 수정",
+                style = BookiiBookiiTheme.typography.bold24,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            CloseButton(onClick = onDismiss)
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = "나의 배송지",
+                style = BookiiBookiiTheme.typography.regular16,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            DUMMY_ADDRESSES.forEachIndexed { index, address ->
+                AddressButton(
+                    title = address.title,
+                    address = address.address,
+                    selected = selectedIndex == index,
+                    onClick = { selectedIndex = index },
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = "직접 입력",
+                    style = BookiiBookiiTheme.typography.regular16,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+                AddressInputBox(placeholder = "건물명, 도로명, 지번으로 검색")
+            }
+            AddressInputBox(placeholder = "상세 주소")
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CardButton(
+                text = "이전",
+                style = CardButtonStyle.White,
+                onClick = onDismiss,
+                modifier = Modifier.weight(1f),
+                height = 48.dp,
+            )
+            CardButton(
+                text = "확인",
+                style = CardButtonStyle.Main,
+                onClick = onConfirmClick,
+                modifier = Modifier.weight(1f),
+                height = 48.dp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AddressButton(
+    title: String,
+    address: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    val backgroundColor = if (selected) {
+        BookiiBookiiTheme.colors.uiMainPale
+    } else {
+        BookiiBookiiTheme.colors.white
+    }
+    val borderColor = if (selected) {
+        BookiiBookiiTheme.colors.uiMain150
+    } else {
+        BookiiBookiiTheme.colors.grey200
+    }
+    val titleColor = if (selected) {
+        BookiiBookiiTheme.colors.uiMain
+    } else {
+        BookiiBookiiTheme.colors.grey700
+    }
+    val addressColor = if (selected) {
+        BookiiBookiiTheme.colors.grey600
+    } else {
+        BookiiBookiiTheme.colors.grey500
+    }
+    val iconTint = if (selected) {
+        BookiiBookiiTheme.colors.uiMain
+    } else {
+        BookiiBookiiTheme.colors.grey500
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(56.dp)
+            .background(color = backgroundColor, shape = BookiiBookiiTheme.shape.round20)
+            .border(width = 1.dp, color = borderColor, shape = BookiiBookiiTheme.shape.round20)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_map),
+            contentDescription = null,
+            tint = iconTint,
+            modifier = Modifier.size(24.dp),
+        )
+        Column {
+            Text(
+                text = title,
+                style = BookiiBookiiTheme.typography.medium16,
+                color = titleColor,
+            )
+            Text(
+                text = address,
+                style = BookiiBookiiTheme.typography.regular14,
+                color = addressColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AddressInputBox(placeholder: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round16,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey300,
+                shape = BookiiBookiiTheme.shape.round16,
+            )
+            .padding(16.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            text = placeholder,
+            style = BookiiBookiiTheme.typography.regular16,
+            color = BookiiBookiiTheme.colors.grey500,
+        )
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDeliveryAddressEditDialogPreview() {
+    BookiiPreview {
+        TrackerDeliveryAddressEditDialogContent(
+            onDismiss = {},
+            onConfirmClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryInfoDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryInfoDialog.kt
@@ -1,0 +1,211 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.delivery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 택배 배송 정보 확인 다이얼로그
+@Composable
+fun TrackerDeliveryInfoDialog(
+    partnerNickname: String,
+    onDismiss: () -> Unit,
+    onEditClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDeliveryInfoDialogContent(
+            partnerNickname = partnerNickname,
+            onDismiss = onDismiss,
+            onEditClick = onEditClick,
+            onConfirmClick = onConfirmClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDeliveryInfoDialogContent(
+    partnerNickname: String,
+    onDismiss: () -> Unit,
+    onEditClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedTabIndex by remember { mutableStateOf(0) }
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "배송 정보 확인",
+                style = BookiiBookiiTheme.typography.bold24,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            CloseButton(onClick = onDismiss)
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+        ) {
+            TabItem(
+                text = "나",
+                selected = selectedTabIndex == 0,
+                onClick = { selectedTabIndex = 0 },
+            )
+            TabItem(
+                text = partnerNickname,
+                selected = selectedTabIndex == 1,
+                onClick = { selectedTabIndex = 1 },
+            )
+        }
+
+        InfoField(label = "수령인", value = "장우영")
+        InfoField(label = "연락처", value = "010-1111-1111")
+        InfoField(label = "주소", value = "서울 용산구 한강로2가 426 101동 202호")
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CardButton(
+                text = "수정",
+                style = CardButtonStyle.White,
+                onClick = onEditClick,
+                modifier = Modifier.weight(1f),
+            )
+            CardButton(
+                text = "확인",
+                style = CardButtonStyle.Main,
+                onClick = onConfirmClick,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TabItem(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .width(IntrinsicSize.Max)
+            .clickable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 4.dp),
+            style = BookiiBookiiTheme.typography.medium18,
+            color = if (selected) {
+                BookiiBookiiTheme.colors.uiMain
+            } else {
+                BookiiBookiiTheme.colors.grey400
+            },
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(
+                    if (selected) BookiiBookiiTheme.colors.uiMain else Color.Transparent,
+                ),
+        )
+    }
+}
+
+@Composable
+private fun InfoField(label: String, value: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = label,
+            style = BookiiBookiiTheme.typography.medium16,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .background(
+                    color = BookiiBookiiTheme.colors.grey100,
+                    shape = BookiiBookiiTheme.shape.round20,
+                )
+                .border(
+                    width = 1.dp,
+                    color = BookiiBookiiTheme.colors.grey200,
+                    shape = BookiiBookiiTheme.shape.round20,
+                )
+                .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            Text(
+                text = value,
+                style = BookiiBookiiTheme.typography.medium16,
+                color = BookiiBookiiTheme.colors.grey900,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDeliveryInfoDialogPreview() {
+    BookiiPreview {
+        TrackerDeliveryInfoDialogContent(
+            partnerNickname = "noshel",
+            onDismiss = {},
+            onEditClick = {},
+            onConfirmClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryReceiveConfirmDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryReceiveConfirmDialog.kt
@@ -1,0 +1,160 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.delivery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 책 수령 확인 다이얼로그
+@Composable
+fun TrackerDeliveryReceiveConfirmDialog(
+    onDismiss: () -> Unit,
+    onConfirmClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDeliveryReceiveConfirmDialogContent(
+            onDismiss = onDismiss,
+            onConfirmClick = onConfirmClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDeliveryReceiveConfirmDialogContent(
+    onDismiss: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isChecked by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "책을 받았나요?",
+                style = BookiiBookiiTheme.typography.bold24,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            CloseButton(onClick = onDismiss)
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            CheckBox(
+                checked = isChecked,
+                onToggle = { isChecked = !isChecked },
+            )
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = "책의 상태를 확인했습니다",
+                    style = BookiiBookiiTheme.typography.regular15,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+                Text(
+                    text = "파손, 훼손, 낙서 등이 있다면 즉시 상대방에게\n댓글로 알려주세요.",
+                    style = BookiiBookiiTheme.typography.regular15,
+                    color = BookiiBookiiTheme.colors.grey600,
+                )
+            }
+        }
+
+        CardButton(
+            text = "받았어요",
+            style = if (isChecked) CardButtonStyle.Main else CardButtonStyle.Grey,
+            onClick = if (isChecked) onConfirmClick else {{}},
+            modifier = Modifier.fillMaxWidth(),
+            shape = BookiiBookiiTheme.shape.round20,
+            textStyle = BookiiBookiiTheme.typography.bold18,
+        )
+    }
+}
+
+@Composable
+private fun CheckBox(
+    checked: Boolean,
+    onToggle: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(20.dp)
+            .background(
+                color = if (checked) {
+                    BookiiBookiiTheme.colors.uiMainPale
+                } else {
+                    BookiiBookiiTheme.colors.grey200
+                },
+                shape = BookiiBookiiTheme.shape.round5,
+            )
+            .clickable(onClick = onToggle),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_check),
+            contentDescription = null,
+            tint = if (checked) {
+                BookiiBookiiTheme.colors.uiMain
+            } else {
+                BookiiBookiiTheme.colors.white
+            },
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDeliveryReceiveConfirmDialogPreview() {
+    BookiiPreview {
+        TrackerDeliveryReceiveConfirmDialogContent(
+            onDismiss = {},
+            onConfirmClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryShippingConfirmDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryShippingConfirmDialog.kt
@@ -2,23 +2,15 @@ package com.bookiibookii.bookiibookii.tracker.ui.detail.delivery
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,37 +23,32 @@ import com.bookiibookii.bookiibookii.ui.component.CloseButton
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
-// 택배 배송 정보 확인 다이얼로그
+// 운송장 정보 확인 다이얼로그
 @Composable
-fun TrackerDeliveryInfoDialog(
-    partnerNickname: String,
+fun TrackerDeliveryShippingConfirmDialog(
     onDismiss: () -> Unit,
-    onEditClick: () -> Unit,
+    onTrackingSearchClick: () -> Unit,
     onConfirmClick: () -> Unit,
 ) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
-        TrackerDeliveryInfoDialogContent(
-            partnerNickname = partnerNickname,
+        TrackerDeliveryShippingConfirmDialogContent(
             onDismiss = onDismiss,
-            onEditClick = onEditClick,
+            onTrackingSearchClick = onTrackingSearchClick,
             onConfirmClick = onConfirmClick,
         )
     }
 }
 
 @Composable
-private fun TrackerDeliveryInfoDialogContent(
-    partnerNickname: String,
+private fun TrackerDeliveryShippingConfirmDialogContent(
     onDismiss: () -> Unit,
-    onEditClick: () -> Unit,
+    onTrackingSearchClick: () -> Unit,
     onConfirmClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedTabIndex by remember { mutableStateOf(0) }
-
     Column(
         modifier = modifier
             .padding(horizontal = 24.dp)
@@ -81,40 +68,24 @@ private fun TrackerDeliveryInfoDialogContent(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                text = "배송 정보 확인",
+                text = "운송장 정보 확인",
                 style = BookiiBookiiTheme.typography.bold24,
                 color = BookiiBookiiTheme.colors.grey900,
             )
             CloseButton(onClick = onDismiss)
         }
 
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(24.dp),
-        ) {
-            TabItem(
-                text = "나",
-                selected = selectedTabIndex == 0,
-                onClick = { selectedTabIndex = 0 },
-            )
-            TabItem(
-                text = partnerNickname,
-                selected = selectedTabIndex == 1,
-                onClick = { selectedTabIndex = 1 },
-            )
-        }
-
-        InfoField(label = "수령인", value = "장우영")
-        InfoField(label = "연락처", value = "010-1111-1111")
-        InfoField(label = "주소", value = "서울 용산구 한강로2가 426 101동 202호")
+        ReadOnlyField(label = "택배사", value = "CJ대한통운")
+        ReadOnlyField(label = "운송장 번호", value = "790335274231")
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             CardButton(
-                text = "수정",
+                text = "배송 조회",
                 style = CardButtonStyle.White,
-                onClick = onEditClick,
+                onClick = onTrackingSearchClick,
                 modifier = Modifier.weight(1f),
             )
             CardButton(
@@ -128,55 +99,32 @@ private fun TrackerDeliveryInfoDialogContent(
 }
 
 @Composable
-private fun TabItem(
-    text: String,
-    selected: Boolean,
-    onClick: () -> Unit,
-) {
-    Column(
-        modifier = Modifier
-            .width(IntrinsicSize.Max)
-            .clickable(onClick = onClick),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text(
-            text = text,
-            modifier = Modifier.padding(horizontal = 4.dp),
-            style = BookiiBookiiTheme.typography.medium18,
-            color = if (selected) {
-                BookiiBookiiTheme.colors.uiMain
-            } else {
-                BookiiBookiiTheme.colors.grey400
-            },
-        )
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(2.dp)
-                .background(
-                    if (selected) BookiiBookiiTheme.colors.uiMain else Color.Transparent,
-                ),
-        )
-    }
-}
-
-@Composable
-private fun InfoField(label: String, value: String) {
+private fun ReadOnlyField(label: String, value: String) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Text(
-            text = label,
-            style = BookiiBookiiTheme.typography.regular16,
-            color = BookiiBookiiTheme.colors.grey900,
-        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                style = BookiiBookiiTheme.typography.regular16,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            Text(
+                text = "*",
+                style = BookiiBookiiTheme.typography.regular14,
+                color = BookiiBookiiTheme.colors.uiMain,
+            )
+        }
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp)
                 .background(
-                    color = BookiiBookiiTheme.colors.grey100,
+                    color = BookiiBookiiTheme.colors.white,
                     shape = BookiiBookiiTheme.shape.round20,
                 )
                 .border(
@@ -199,12 +147,11 @@ private fun InfoField(label: String, value: String) {
 
 @Preview(widthDp = 412, showBackground = true)
 @Composable
-private fun TrackerDeliveryInfoDialogPreview() {
+private fun TrackerDeliveryShippingConfirmDialogPreview() {
     BookiiPreview {
-        TrackerDeliveryInfoDialogContent(
-            partnerNickname = "noshel",
+        TrackerDeliveryShippingConfirmDialogContent(
             onDismiss = {},
-            onEditClick = {},
+            onTrackingSearchClick = {},
             onConfirmClick = {},
         )
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryTrackingNumberDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/delivery/TrackerDeliveryTrackingNumberDialog.kt
@@ -1,0 +1,180 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.delivery
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 운송장 등록 다이얼로그
+@Composable
+fun TrackerDeliveryTrackingNumberDialog(
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDeliveryTrackingNumberDialogContent(onDismiss = onDismiss)
+    }
+}
+
+@Composable
+private fun TrackerDeliveryTrackingNumberDialogContent(
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "운송장 등록",
+                style = BookiiBookiiTheme.typography.bold24,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            CloseButton(onClick = onDismiss)
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            RequiredLabel(text = "택배사")
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .background(
+                        color = BookiiBookiiTheme.colors.grey100,
+                        shape = BookiiBookiiTheme.shape.round20,
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = BookiiBookiiTheme.colors.grey200,
+                        shape = BookiiBookiiTheme.shape.round20,
+                    )
+                    .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "택배사를 선택해주세요",
+                    style = BookiiBookiiTheme.typography.medium16,
+                    color = BookiiBookiiTheme.colors.grey500,
+                )
+                Icon(
+                    painter = painterResource(R.drawable.ic_chevron),
+                    contentDescription = null,
+                    tint = BookiiBookiiTheme.colors.grey500,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .rotate(-90f),
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            RequiredLabel(text = "운송장 번호")
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .background(
+                        color = BookiiBookiiTheme.colors.grey100,
+                        shape = BookiiBookiiTheme.shape.round20,
+                    )
+                    .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    text = "숫자만 입력해주세요",
+                    style = BookiiBookiiTheme.typography.medium16,
+                    color = BookiiBookiiTheme.colors.grey500,
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .background(
+                    color = BookiiBookiiTheme.colors.grey200,
+                    shape = BookiiBookiiTheme.shape.round20,
+                )
+                .padding(horizontal = 18.dp, vertical = 12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "완료",
+                style = BookiiBookiiTheme.typography.regular16,
+                color = BookiiBookiiTheme.colors.grey500,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RequiredLabel(text: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.regular16,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+        Text(
+            text = "*",
+            style = BookiiBookiiTheme.typography.regular14,
+            color = BookiiBookiiTheme.colors.uiMain,
+        )
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDeliveryTrackingNumberDialogPreview() {
+    BookiiPreview {
+        TrackerDeliveryTrackingNumberDialogContent(onDismiss = {})
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/main/TrackerMainCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/main/TrackerMainCard.kt
@@ -1,16 +1,17 @@
 package com.bookiibookii.bookiibookii.tracker.ui.main
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,9 +19,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.tracker.model.TrackerCardModel
 import com.bookiibookii.bookiibookii.tracker.model.TrackerProfileItem
 import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
@@ -195,13 +199,17 @@ private fun TrackerProfileColumn(
             }
         }
         Box(
-            // TODO: 나중에 정확한 값으로
             modifier = Modifier
                 .offset(x = 17.dp, y = 0.dp)
-                .size(44.dp)
-                .clip(CircleShape)
-                .background(BookiiBookiiTheme.colors.grey300),
-        )
+                .size(44.dp),
+        ) {
+            Image(
+                painter = painterResource(R.drawable.profile_bg),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey500),
+            )
+        }
     }
 }
 

--- a/app/src/main/res/drawable/profile_bg.xml
+++ b/app/src/main/res/drawable/profile_bg.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="44dp"
+    android:height="44dp"
+    android:viewportWidth="44"
+    android:viewportHeight="44">
+  <path
+      android:pathData="M0,22C0,3.883 3.883,0 22,0C40.117,0 44,3.883 44,22C44,40.117 40.117,44 22,44C3.883,44 0,40.117 0,22Z"
+      android:fillColor="#ffffff"/>
+</vector>


### PR DESCRIPTION
# 📌 Pull Request Title
> - ui: 트래커 택배교환 공용 모달 (#302)

---

# ✨ 작업 내용 (What)
> - 트래커 상세 단계 리스트 
<img width="458" height="386" alt="image" src="https://github.com/user-attachments/assets/3fd8e774-3f1a-4c36-a796-0016be91b798" />
> - 공통 상세
<img width="286" height="337" alt="image" src="https://github.com/user-attachments/assets/88d8ae67-f4b4-4284-b2e3-1d9e977fb3df" />
> - 배송 정보 확인 다이어로그
<img width="309" height="369" alt="image" src="https://github.com/user-attachments/assets/7afe4d92-beb8-4eac-a18b-b560aac890ca" />
> - 배송 정보 수정 다이어로그
<img width="325" height="356" alt="image" src="https://github.com/user-attachments/assets/bf5ec586-3f98-409c-a47d-038d1d481700" />
> - 운송장 등록 다이어로그 
> - 운송장 정보 확인 다이어로그
> - 수령 인증 확인 다이어로그

---

# 🔗 관련 이슈 (Optional)
- close #302 
