### PR TITLE
ui: 직접교환 공통 모달 (#306)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerReadingPeriodEditDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerReadingPeriodEditDialog.kt
@@ -104,6 +104,7 @@ private fun TrackerReadingPeriodEditDialogContent(
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectExchangeConfirmDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectExchangeConfirmDialog.kt
@@ -1,0 +1,113 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.direct
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 직접교환 완료 확인 다이얼로그
+@Composable
+fun TrackerDirectExchangeConfirmDialog(
+    onDismiss: () -> Unit,
+    onNotYetClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDirectExchangeConfirmDialogContent(
+            onDismiss = onDismiss,
+            onNotYetClick = onNotYetClick,
+            onConfirmClick = onConfirmClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDirectExchangeConfirmDialogContent(
+    onDismiss: () -> Unit,
+    onNotYetClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "책을 교환하셨나요?",
+                style = BookiiBookiiTheme.typography.bold24,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            CloseButton(onClick = onDismiss)
+        }
+
+        Text(
+            text = "상대방과 교환을 완료했는지 확인해주세요.",
+            style = BookiiBookiiTheme.typography.medium16,
+            color = BookiiBookiiTheme.colors.grey700,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CardButton(
+                text = "못했어요",
+                style = CardButtonStyle.White,
+                onClick = onNotYetClick,
+                modifier = Modifier.weight(1f),
+            )
+            CardButton(
+                text = "교환했어요",
+                style = CardButtonStyle.Main,
+                onClick = onConfirmClick,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDirectExchangeConfirmDialogPreview() {
+    BookiiPreview {
+        TrackerDirectExchangeConfirmDialogContent(
+            onDismiss = {},
+            onNotYetClick = {},
+            onConfirmClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectExchangeFailDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectExchangeFailDialog.kt
@@ -1,0 +1,113 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.direct
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 직접교환 실패 안내 다이얼로그
+@Composable
+fun TrackerDirectExchangeFailDialog(
+    onDismiss: () -> Unit,
+    onReportClick: () -> Unit,
+    onGoToCommentsClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDirectExchangeFailDialogContent(
+            onDismiss = onDismiss,
+            onReportClick = onReportClick,
+            onGoToCommentsClick = onGoToCommentsClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDirectExchangeFailDialogContent(
+    onDismiss: () -> Unit,
+    onReportClick: () -> Unit,
+    onGoToCommentsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = "책을 교환하지 못했나요?",
+                style = BookiiBookiiTheme.typography.bold24,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+            CloseButton(onClick = onDismiss)
+        }
+
+        Text(
+            text = "상대방과 연락하여 약속을 다시 잡거나, 일방적인 노쇼라면 신고를 진행해 주세요.",
+            style = BookiiBookiiTheme.typography.medium16,
+            color = BookiiBookiiTheme.colors.grey700,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CardButton(
+                text = "신고하기",
+                style = CardButtonStyle.White,
+                onClick = onReportClick,
+                modifier = Modifier.weight(1f),
+            )
+            CardButton(
+                text = "댓글 바로가기",
+                style = CardButtonStyle.Main,
+                onClick = onGoToCommentsClick,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDirectExchangeFailDialogPreview() {
+    BookiiPreview {
+        TrackerDirectExchangeFailDialogContent(
+            onDismiss = {},
+            onReportClick = {},
+            onGoToCommentsClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectMeetingConfirmDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectMeetingConfirmDialog.kt
@@ -1,0 +1,169 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.direct
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 직접교환 약속 잡기 3/3 - 약속 확인
+@Composable
+fun TrackerDirectMeetingConfirmDialog(
+    onDismiss: () -> Unit,
+    onConfirmClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDirectMeetingConfirmDialogContent(
+            onDismiss = onDismiss,
+            onConfirmClick = onConfirmClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDirectMeetingConfirmDialogContent(
+    onDismiss: () -> Unit,
+    onConfirmClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                StepChip(text = "3/3")
+                Text(
+                    text = "약속을 확인해주세요!",
+                    style = BookiiBookiiTheme.typography.bold24,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+            }
+            CloseButton(onClick = onDismiss)
+        }
+
+        ReadOnlyField(label = "일시", value = "2026. 01. 19. 14:00")
+        ReadOnlyField(label = "장소", value = "메가MGC커피 역삼초교교차로점 문 앞")
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CardButton(
+                text = "취소",
+                style = CardButtonStyle.Grey,
+                onClick = onDismiss,
+                modifier = Modifier.weight(1f),
+            )
+            CardButton(
+                text = "다음",
+                style = CardButtonStyle.Main,
+                onClick = onConfirmClick,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepChip(text: String) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round8,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round8,
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium14,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+    }
+}
+
+@Composable
+private fun ReadOnlyField(label: String, value: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = label,
+            style = BookiiBookiiTheme.typography.regular16,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .background(
+                    color = BookiiBookiiTheme.colors.grey100,
+                    shape = BookiiBookiiTheme.shape.round20,
+                )
+                .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            Text(
+                text = value,
+                style = BookiiBookiiTheme.typography.medium16,
+                color = BookiiBookiiTheme.colors.grey900,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDirectMeetingConfirmDialogPreview() {
+    BookiiPreview {
+        TrackerDirectMeetingConfirmDialogContent(
+            onDismiss = {},
+            onConfirmClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectMeetingPlaceDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectMeetingPlaceDialog.kt
@@ -1,0 +1,268 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.direct
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 직접교환 약속 잡기 2/3 - 장소 선택
+@Composable
+fun TrackerDirectMeetingPlaceDialog(
+    onDismiss: () -> Unit,
+    onPreviousClick: () -> Unit,
+    onNextClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDirectMeetingPlaceDialogContent(
+            onDismiss = onDismiss,
+            onPreviousClick = onPreviousClick,
+            onNextClick = onNextClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDirectMeetingPlaceDialogContent(
+    onDismiss: () -> Unit,
+    onPreviousClick: () -> Unit,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                StepChip(text = "2/3")
+                Text(
+                    text = "어디서 만날까요?",
+                    style = BookiiBookiiTheme.typography.bold24,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+            }
+            CloseButton(onClick = onDismiss)
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            SearchInput(placeholder = "지번, 도로명, 건물명으로 검색")
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                PlaceField(value = "메가MGC커피 역삼초교교차로점")
+                DetailAddressField(placeholder = "상세주소를 입력해주세요")
+            }
+
+            LoadMyPlacesButton(text = "나의 희망교환장소 불러오기")
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CardButton(
+                text = "이전",
+                style = CardButtonStyle.Grey,
+                onClick = onPreviousClick,
+                modifier = Modifier.weight(1f),
+            )
+            CardButton(
+                text = "다음",
+                style = CardButtonStyle.Main,
+                onClick = onNextClick,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepChip(text: String) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round8,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round8,
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium14,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+    }
+}
+
+@Composable
+private fun SearchInput(placeholder: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round20,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round20,
+            )
+            .padding(horizontal = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_search),
+            contentDescription = null,
+            tint = BookiiBookiiTheme.colors.grey500,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = placeholder,
+            style = BookiiBookiiTheme.typography.regular16,
+            color = BookiiBookiiTheme.colors.grey300,
+        )
+    }
+}
+
+@Composable
+private fun PlaceField(value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .background(
+                color = BookiiBookiiTheme.colors.grey100,
+                shape = BookiiBookiiTheme.shape.round20,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round20,
+            )
+            .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = value,
+            style = BookiiBookiiTheme.typography.medium16,
+            color = BookiiBookiiTheme.colors.grey900,
+            maxLines = 1,
+        )
+        Box(modifier = Modifier.size(24.dp))
+    }
+}
+
+@Composable
+private fun DetailAddressField(placeholder: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .background(
+                color = BookiiBookiiTheme.colors.grey100,
+                shape = BookiiBookiiTheme.shape.round20,
+            )
+            .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Text(
+            text = placeholder,
+            style = BookiiBookiiTheme.typography.medium16,
+            color = BookiiBookiiTheme.colors.grey500,
+        )
+    }
+}
+
+@Composable
+private fun LoadMyPlacesButton(text: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .background(
+                color = BookiiBookiiTheme.colors.uiMainPale,
+                shape = BookiiBookiiTheme.shape.round16,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.uiMain150,
+                shape = BookiiBookiiTheme.shape.round16,
+            )
+            .padding(horizontal = 18.dp, vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.regular15,
+            color = BookiiBookiiTheme.colors.uiMain,
+        )
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDirectMeetingPlaceDialogPreview() {
+    BookiiPreview {
+        TrackerDirectMeetingPlaceDialogContent(
+            onDismiss = {},
+            onPreviousClick = {},
+            onNextClick = {},
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectMeetingTimeDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/direct/TrackerDirectMeetingTimeDialog.kt
@@ -1,0 +1,423 @@
+package com.bookiibookii.bookiibookii.tracker.ui.detail.direct
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.component.CardButton
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.CloseButton
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+import java.time.LocalDate
+import java.time.YearMonth
+
+private val WEEKDAY_LABELS = listOf("일", "월", "화", "수", "목", "금", "토")
+
+private data class DayCell(
+    val date: LocalDate,
+    val isCurrentMonth: Boolean,
+)
+
+// 직접교환 약속 잡기 1/3 - 일시 선택
+@Composable
+fun TrackerDirectMeetingTimeDialog(
+    onDismiss: () -> Unit,
+    onNextClick: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        TrackerDirectMeetingTimeDialogContent(
+            onDismiss = onDismiss,
+            onNextClick = onNextClick,
+        )
+    }
+}
+
+@Composable
+private fun TrackerDirectMeetingTimeDialogContent(
+    onDismiss: () -> Unit,
+    onNextClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val today = LocalDate.of(2026, 5, 23)
+    var displayMonth by remember { mutableStateOf(YearMonth.of(2026, 5)) }
+    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+    var isAm by remember { mutableStateOf(true) }
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = 24.dp)
+            .fillMaxWidth()
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round24,
+            )
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                StepChip(text = "1/3")
+                Text(
+                    text = "언제 만날까요?",
+                    style = BookiiBookiiTheme.typography.bold24,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+            }
+            CloseButton(onClick = onDismiss)
+        }
+
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clickable { displayMonth = displayMonth.minusMonths(1) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_chevron),
+                        contentDescription = "이전 달",
+                        tint = BookiiBookiiTheme.colors.black,
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
+                Text(
+                    text = "${displayMonth.year}년 ${displayMonth.monthValue}월",
+                    style = BookiiBookiiTheme.typography.semibold20,
+                    color = BookiiBookiiTheme.colors.grey900,
+                )
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clickable { displayMonth = displayMonth.plusMonths(1) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_chevron),
+                        contentDescription = "다음 달",
+                        tint = BookiiBookiiTheme.colors.black,
+                        modifier = Modifier
+                            .size(28.dp)
+                            .rotate(180f),
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    WEEKDAY_LABELS.forEach { label ->
+                        Box(
+                            modifier = Modifier.width(32.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = label,
+                                style = BookiiBookiiTheme.typography.medium16,
+                                color = BookiiBookiiTheme.colors.grey700,
+                            )
+                        }
+                    }
+                }
+
+                buildCalendarGrid(displayMonth).forEach { week ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        week.forEach { cell ->
+                            DayCellView(
+                                cell = cell,
+                                today = today,
+                                selectedDate = selectedDate,
+                                onClick = { date ->
+                                    selectedDate = if (selectedDate == date) null else date
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+
+            TimePickerRow(
+                isAm = isAm,
+                onAmPmChange = { isAm = it },
+                hour = "06",
+                minute = "00",
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            CardButton(
+                text = "취소",
+                style = CardButtonStyle.Grey,
+                onClick = onDismiss,
+                modifier = Modifier.weight(1f),
+            )
+            CardButton(
+                text = "다음",
+                style = if (selectedDate != null) CardButtonStyle.Main else CardButtonStyle.Grey,
+                onClick = if (selectedDate != null) onNextClick else {{}},
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StepChip(text: String) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = BookiiBookiiTheme.colors.white,
+                shape = BookiiBookiiTheme.shape.round8,
+            )
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round8,
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.medium14,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+    }
+}
+
+@Composable
+private fun TimePickerRow(
+    isAm: Boolean,
+    onAmPmChange: (Boolean) -> Unit,
+    hour: String,
+    minute: String,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        HorizontalDivider(thickness = 1.dp, color = BookiiBookiiTheme.colors.uiBg)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            AmPmToggle(isAm = isAm, onChange = onAmPmChange)
+            TimeBox(value = hour, suffix = "시")
+            TimeBox(value = minute, suffix = "분")
+        }
+        HorizontalDivider(thickness = 1.dp, color = BookiiBookiiTheme.colors.uiBg)
+    }
+}
+
+@Composable
+private fun AmPmToggle(
+    isAm: Boolean,
+    onChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .background(
+                color = BookiiBookiiTheme.colors.grey200,
+                shape = BookiiBookiiTheme.shape.round12,
+            )
+            .padding(2.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        AmPmChip(text = "오전", selected = isAm, onClick = { onChange(true) })
+        AmPmChip(text = "오후", selected = !isAm, onClick = { onChange(false) })
+    }
+}
+
+@Composable
+private fun AmPmChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = if (selected) {
+                    BookiiBookiiTheme.colors.white
+                } else {
+                    BookiiBookiiTheme.colors.grey200
+                },
+                shape = BookiiBookiiTheme.shape.round10,
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 6.dp, vertical = 2.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BookiiBookiiTheme.typography.regular14,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+    }
+}
+
+@Composable
+private fun TimeBox(value: String, suffix: String) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .width(80.dp)
+                .border(
+                    width = 1.dp,
+                    color = BookiiBookiiTheme.colors.grey200,
+                    shape = BookiiBookiiTheme.shape.round12,
+                )
+                .padding(4.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = value,
+                style = BookiiBookiiTheme.typography.regular14,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
+        }
+        Text(
+            text = suffix,
+            style = BookiiBookiiTheme.typography.regular14,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+    }
+}
+
+private fun buildCalendarGrid(month: YearMonth): List<List<DayCell>> {
+    val firstDayOfMonth = month.atDay(1)
+    val daysFromPrevMonth = firstDayOfMonth.dayOfWeek.value % 7
+    val gridStart = firstDayOfMonth.minusDays(daysFromPrevMonth.toLong())
+    return List(6) { week ->
+        List(7) { day ->
+            val date = gridStart.plusDays((week * 7 + day).toLong())
+            DayCell(
+                date = date,
+                isCurrentMonth = YearMonth.from(date) == month,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DayCellView(
+    cell: DayCell,
+    today: LocalDate,
+    selectedDate: LocalDate?,
+    onClick: (LocalDate) -> Unit,
+) {
+    val isCurrentMonth = cell.isCurrentMonth
+    val isSelectable = isCurrentMonth && cell.date.isAfter(today)
+    val isToday = isCurrentMonth && cell.date == today
+    val isSelected = isCurrentMonth && cell.date == selectedDate
+
+    val textColor = when {
+        !isCurrentMonth -> BookiiBookiiTheme.colors.grey400
+        isSelected -> BookiiBookiiTheme.colors.uiMain
+        isToday -> BookiiBookiiTheme.colors.uiMainSub
+        else -> BookiiBookiiTheme.colors.grey900
+    }
+
+    val bgColor = if (isSelected) {
+        BookiiBookiiTheme.colors.uiMainPale
+    } else {
+        Color.Transparent
+    }
+
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .background(color = bgColor, shape = BookiiBookiiTheme.shape.round10)
+            .clickable(enabled = isSelectable) { onClick(cell.date) },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = cell.date.dayOfMonth.toString(),
+            style = BookiiBookiiTheme.typography.medium15,
+            color = textColor,
+        )
+        if (isToday) {
+            Box(
+                modifier = Modifier
+                    .size(4.dp)
+                    .align(Alignment.BottomCenter)
+                    .background(
+                        color = BookiiBookiiTheme.colors.uiMainSub,
+                        shape = CircleShape,
+                    ),
+            )
+        }
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true)
+@Composable
+private fun TrackerDirectMeetingTimeDialogPreview() {
+    BookiiPreview {
+        TrackerDirectMeetingTimeDialogContent(
+            onDismiss = {},
+            onNextClick = {},
+        )
+    }
+}


### PR DESCRIPTION
# 📌 Pull Request Title
> - ui: 직접교환 공통 모달 (#306)

---

# ✨ 작업 내용 (What)
> - 약속 등록 Step 1, 2, 3
<img width="259" height="344" alt="image" src="https://github.com/user-attachments/assets/a855a55b-fc96-47b1-9168-717790976809" />
<img width="371" height="398" alt="image" src="https://github.com/user-attachments/assets/a2cde952-b8f0-4549-84c2-35e16aa2f7f4" />
<img width="377" height="352" alt="image" src="https://github.com/user-attachments/assets/e46c0820-7a5e-440a-9694-b8271f36d900" />

> - 직접교환 완료 및 실패 다이얼로그
<img width="393" height="233" alt="image" src="https://github.com/user-attachments/assets/d87de849-15c3-414f-8352-7b983a019451" />
<img width="400" height="268" alt="image" src="https://github.com/user-attachments/assets/3ab0b9b1-92d3-46a0-8408-051bfef0795b" />

---

# 🔗 관련 이슈 (Optional)
- close #306
