### PR TITLE
feat: 댓글 ui 완성 및 그룹 상세 api 연결 (#312)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/common/DateUtils.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/common/DateUtils.kt
@@ -1,7 +1,9 @@
 package com.bookiibookii.bookiibookii.common
 
 import java.time.Instant
+import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -10,10 +12,18 @@ object DateUtils {
         .ofPattern("yyyy. MM. dd.", Locale.US)
         .withZone(ZoneId.systemDefault())
 
+    // 서버 시간 문자열 → Instant
+    // "...Z"/offset 있으면 Instant.parse, 없으면 UTC LocalDateTime으로 간주
+    private fun parseInstant(serverTime: String): Instant = try {
+        Instant.parse(serverTime)
+    } catch (e: Exception) {
+        LocalDateTime.parse(serverTime).toInstant(ZoneOffset.UTC)
+    }
+
     fun formatDate(dateString: String?): String {
         if (dateString.isNullOrBlank()) return "0000. 00. 00."
         return try {
-            formatter.format(Instant.parse(dateString))
+            formatter.format(parseInstant(dateString))
         } catch (e: Exception) {
             "0000. 00. 00."
         }
@@ -22,7 +32,7 @@ object DateUtils {
     fun calculateTimeAgo(serverTime: String?): String {
         if (serverTime.isNullOrEmpty()) return ""
         return try {
-            val instant = Instant.parse(serverTime)
+            val instant = parseInstant(serverTime)
             val diff = System.currentTimeMillis() - instant.toEpochMilli()
             val minutes = diff / (1000 * 60)
             val hours = minutes / 60

--- a/app/src/main/java/com/bookiibookii/bookiibookii/common/DateUtils.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/common/DateUtils.kt
@@ -1,78 +1,39 @@
 package com.bookiibookii.bookiibookii.common
 
-import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
-import java.util.TimeZone
 
 object DateUtils {
-    // 1. 서버 시간을 "yyyy. MM. dd." 형식으로 변환
+    private val formatter = DateTimeFormatter
+        .ofPattern("yyyy. MM. dd.", Locale.US)
+        .withZone(ZoneId.systemDefault())
+
     fun formatDate(dateString: String?): String {
         if (dateString.isNullOrBlank()) return "0000. 00. 00."
-        if (dateString.contains("0000")) return "0000. 00. 00."
-
-        // ★ 핵심 해결책: 서버에서 이미 "2026. 02. 19." 처럼 완벽하게 보내준다면 파싱/자르기 없이 바로 리턴!
-        if (dateString.contains(". ") && !dateString.contains("T")) {
-            return if (dateString.endsWith(".")) dateString else "$dateString."
-        }
-
         return try {
-            val date = if (dateString.contains("T")) {
-                val format = if (dateString.contains(".")) "yyyy-MM-dd'T'HH:mm:ss.SSS" else "yyyy-MM-dd'T'HH:mm:ss"
-                val parser = SimpleDateFormat(format, Locale.getDefault())
-                parser.timeZone = TimeZone.getTimeZone("UTC")
-                parser.parse(dateString)
-            } else {
-                val parser = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-                parser.parse(dateString)
-            }
-
-            if (date != null) {
-                val formatter = SimpleDateFormat("yyyy. MM. dd.", Locale.getDefault())
-                formatter.timeZone = TimeZone.getDefault()
-                formatter.format(date)
-            } else {
-                fallbackFormat(dateString)
-            }
+            formatter.format(Instant.parse(dateString))
         } catch (e: Exception) {
-            fallbackFormat(dateString)
+            "0000. 00. 00."
         }
     }
 
-    // 1-1. 최후의 방어선 (글자 수로 무작정 자르지 않고 안전하게 처리)
-    private fun fallbackFormat(dateStr: String): String {
-        // T를 기준으로 앞의 날짜 부분만 가져옵니다.
-        val onlyDate = if (dateStr.contains("T")) dateStr.substringBefore("T") else dateStr
-        val dotted = onlyDate.replace("-", ". ")
-        return if (dotted.endsWith(".")) dotted else "$dotted."
-    }
-
-    // 2. 채팅이나 댓글용 "방금 전", "N시간 전" 변환
     fun calculateTimeAgo(serverTime: String?): String {
         if (serverTime.isNullOrEmpty()) return ""
         return try {
-            val format = if (serverTime.contains(".")) "yyyy-MM-dd'T'HH:mm:ss.SSS" else "yyyy-MM-dd'T'HH:mm:ss"
-            val parser = SimpleDateFormat(format, Locale.getDefault())
-            parser.timeZone = TimeZone.getTimeZone("UTC")
-            val date = parser.parse(serverTime) ?: return fallbackFormat(serverTime)
-
-            val now = System.currentTimeMillis()
-            val diff = now - date.time
-
+            val instant = Instant.parse(serverTime)
+            val diff = System.currentTimeMillis() - instant.toEpochMilli()
             val minutes = diff / (1000 * 60)
             val hours = minutes / 60
-
             when {
                 minutes < 1 -> "방금 전"
                 minutes < 60 -> "${minutes}분 전"
                 hours < 24 -> "${hours}시간 전"
-                else -> {
-                    val formatter = SimpleDateFormat("yyyy. MM. dd.", Locale.getDefault())
-                    formatter.timeZone = TimeZone.getDefault()
-                    formatter.format(date)
-                }
+                else -> formatter.format(instant)
             }
         } catch (e: Exception) {
-            fallbackFormat(serverTime)
+            ""
         }
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/GrpApi.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/GrpApi.kt
@@ -4,7 +4,6 @@ import com.bookiibookii.bookiibookii.data.model.common.ApiResponse
 import com.bookiibookii.bookiibookii.data.model.group.BookSearchResponse
 import com.bookiibookii.bookiibookii.data.model.group.CommentCreateRequest
 import com.bookiibookii.bookiibookii.data.model.group.CommentCreateResponse
-import com.bookiibookii.bookiibookii.data.model.group.CommentDeleteResponse
 import com.bookiibookii.bookiibookii.data.model.group.CommentItem
 import com.bookiibookii.bookiibookii.data.model.group.GroupAppListResponse
 import com.bookiibookii.bookiibookii.data.model.group.GroupAppStatusRequest
@@ -125,10 +124,10 @@ interface GrpApi {
         @Path("groupId") groupId: Long
     ): Response<ApiResponse<List<CommentItem>>>
 
-    // 그룹 댓글 삭제
+    // 그룹 댓글 삭제 — ApiResponseVoid (result 없음, 프로젝트 컨벤션상 String으로 받음)
     @DELETE("api/groups/{groupId}/comments/{commentId}")
     suspend fun deleteComment(
-        @Path("groupId") groupId: Int,
-        @Path("commentId") commentId: Int
-    ): Response<ApiResponse<CommentDeleteResponse>>
+        @Path("groupId") groupId: Long,
+        @Path("commentId") commentId: Long
+    ): Response<ApiResponse<String>>
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/GrpApi.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/GrpApi.kt
@@ -70,7 +70,7 @@ interface GrpApi {
     // 그룹 상세 조회
     @GET("api/groups/{groupId}")
     suspend fun getGroupDetail(
-        @Path("groupId") groupId: Int
+        @Path("groupId") groupId: Long
     ): Response<ApiResponse<GroupDetailResponse>>
 
     // 그룹 신청하기

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/GrpApi.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/GrpApi.kt
@@ -124,7 +124,7 @@ interface GrpApi {
         @Path("groupId") groupId: Long
     ): Response<ApiResponse<List<CommentItem>>>
 
-    // 그룹 댓글 삭제 — ApiResponseVoid (result 없음, 프로젝트 컨벤션상 String으로 받음)
+    // 그룹 댓글 삭제
     @DELETE("api/groups/{groupId}/comments/{commentId}")
     suspend fun deleteComment(
         @Path("groupId") groupId: Long,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/CommentCreate.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/CommentCreate.kt
@@ -3,7 +3,7 @@ package com.bookiibookii.bookiibookii.data.model.group
 data class CommentCreateRequest(
     val content: String,
     val parentId: Long?,
-    val secret: Boolean
+    val secret: Boolean = false,    // 대댓글일 때만 true
 )
 
 data class CommentCreateResponse(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/CommentDelete.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/CommentDelete.kt
@@ -1,6 +1,0 @@
-package com.bookiibookii.bookiibookii.data.model.group
-
-data class CommentDeleteResponse(
-    val commentId: Long,
-    val deletedAt: String
-)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/CommentList.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/CommentList.kt
@@ -5,7 +5,7 @@ data class CommentItem(
     val deleted: Boolean,
     val secret: Boolean,
     val content: String,
-    var parentId: Long?,
+    val parentId: Long?,
     val writer: CommentWriter,
     val createdAt: String,
     val children: List<CommentItem>? = null

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/GroupDetail.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/GroupDetail.kt
@@ -1,38 +1,56 @@
 package com.bookiibookii.bookiibookii.data.model.group
 
-import com.google.gson.annotations.SerializedName
-
+// GET /api/groups/{groupId} 응답
 data class GroupDetailResponse(
+    // 1. 그룹 및 상태 정보
     val groupId: Long,
+    val groupStatus: String,        // RECRUITING, MATCHED
+    val isHost: Boolean,            // 조회자가 방장인지 여부
+    val tradeType: String,          // DIRECT, DELIVERY
+    val placeName: String,
+    val address: String,
+
+    // 2. 도서 상세 정보
     val title: String,
-    val bookTitle: String,
     val bookImage: String?,
     val author: String,
-    val category: String,
-    val groupStatus: String,
-    val buttonStatus: String,
-    val isHost: Boolean,
-    val readingPeriod: Int,
-    val matchedCount: Int,
-    val maxCapacity: Int,
-    val waitingCount: Int,
-    val isHot: Boolean,
+    val genre: String,              // CustomCategory 명칭
+
+    // 3. 그룹 설정 및 배지 정보
+    val readingPeriod: Int,         // 독서 기간 (day)
+    val matchedCount: Int,          // 현재 확정 인원
+    val maxCapacity: Int,           // 정원
+    val waitingCount: Int,          // 대기자 수
+    val isHot: Boolean,             // 대기자가 정원의 3배 이상인지
     val createdAt: String,
-    val startDate: String,
+    val startDate: String?,         // 미시작 시 null
+
+    // 4. 호스트 정보 및 규칙
     val hostNickname: String,
-    val hostProfileImageUrl: String?,
-    val preferRegion: String?,
-    val meetPlace: String?,
-    val groupTags: List<String>?,
-    val customTag: String?,
-    val groupComment: String?,
-    val participantSlots: List<ParticipantSlot>?
+    val hostProfileImageUrl: String?,   // Presigned GET URL
+
+    // 5. 그룹 소개 및 참여 멤버 슬롯
+    val groupComment: String?,      // 그룹 소개글 (생성 시 선택 입력)
+    val groupName: String,
+    val rules: List<GroupRule>,
+    // 정원 4명 중 2명 참여 시 -> [방장, 게스트1, EMPTY, EMPTY] 순서
+    val participantSlots: List<ParticipantSlot>,
+
+    // APPLY(신청하기), CANCEL(취소하기), MANAGE(요청관리), TRACKER(트래커보기), FULL(인원마감)
+    val buttonStatus: String,
 )
 
+// 그룹 규칙 (응답 전용)
+data class GroupRule(
+    // MEMO / POSTIT / PHOTO / ALL_ROUNDER / NO_IDEA / CUSTOM
+    val tag: String,
+    val content: String,
+)
+
+// 참여 멤버 슬롯
 data class ParticipantSlot(
     val nickname: String?,
-    @SerializedName("profileImageUrl")
-    val profileImage: String?,
-    val role: String,
-    val isMe: Boolean
+    val profileImageUrl: String?,
+    val role: String,               // HOST, GUEST, EMPTY
+    val isMe: Boolean,
 )

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupCommentUiState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupCommentUiState.kt
@@ -1,0 +1,32 @@
+package com.bookiibookii.bookiibookii.group.model
+
+import com.bookiibookii.bookiibookii.data.model.group.CommentItem
+
+// 그룹 상세 화면의 댓글 바텀시트 UI 상태
+data class GroupCommentUiState(
+    // GET 응답
+    val comments: List<CommentItem> = emptyList(),
+    // 헤더 "댓글 N" 표시값. sumOf로 단순 계산
+    val totalCount: Int = 0,
+
+    val loading: Boolean = false,
+    val error: String? = null,
+
+    // 입력 필드 상태
+    val draft: String = "",
+    // 비밀 댓글 토글
+    val draftSecret: Boolean = false,
+    // null이면 일반 댓글 모드, 값 있으면 그 댓글에 대한 답글 모드
+    val replyTargetId: Long? = null,
+    // 답글 멘션에 표시할 닉네임
+    val mentionNickname: String? = null,
+    // startReply 호출마다 증가하는 토큰. 같은 댓글 재클릭(값 동일)에도 focus/키보드 재요청을 트리거하기 위함
+    val replyRequestId: Int = 0,
+
+    // POST 진행 중
+    val submitting: Boolean = false,
+    // 삭제 진행 중인 댓글 id들
+    val deletingIds: Set<Long> = emptySet(),
+) {
+    val isReplyMode: Boolean get() = replyTargetId != null
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupCommentUiState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupCommentUiState.kt
@@ -20,7 +20,7 @@ data class GroupCommentUiState(
     val replyTargetId: Long? = null,
     // 답글 멘션에 표시할 닉네임
     val mentionNickname: String? = null,
-    // startReply 호출마다 증가하는 토큰. 같은 댓글 재클릭(값 동일)에도 focus/키보드 재요청을 트리거하기 위함
+    // startReply 호출마다 증가하는 토큰. 같은 댓글 재클릭에도 focus/키보드 재요청을 트리거하기 위함
     val replyRequestId: Int = 0,
 
     // POST 진행 중

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupDetailActionButton.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupDetailActionButton.kt
@@ -1,0 +1,34 @@
+package com.bookiibookii.bookiibookii.group.model
+
+import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+
+// 그룹 상세 하단 액션 버튼의 표시값
+// VM에서 GroupDetailResponse.buttonStatus + waitingCount를 받아
+// 화면에 내려주는 용도. null이면 버튼 자체를 안그림
+data class GroupDetailActionButton(
+    val text: String,
+    val style: CardButtonStyle,
+)
+
+// - APPLY:   참여 신청하기            (Main)
+// - MANAGE:  참여 요청 관리 {대기자 수} (Main)
+// - CANCEL:  참여 신청 취소           (MainPale)
+// - TRACKER / FULL / 그 외: 버튼 미표시 (null)
+fun groupDetailActionButton(
+    buttonStatus: String,
+    waitingCount: Int,
+): GroupDetailActionButton? = when (buttonStatus) {
+    "APPLY" -> GroupDetailActionButton(
+        text = "참여 신청하기",
+        style = CardButtonStyle.Main,
+    )
+    "MANAGE" -> GroupDetailActionButton(
+        text = "참여 요청 관리 $waitingCount",
+        style = CardButtonStyle.Main,
+    )
+    "CANCEL" -> GroupDetailActionButton(
+        text = "참여 신청 취소",
+        style = CardButtonStyle.MainPale,
+    )
+    else -> null
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupDetailUiState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupDetailUiState.kt
@@ -1,0 +1,15 @@
+package com.bookiibookii.bookiibookii.group.model
+
+import com.bookiibookii.bookiibookii.data.model.group.GroupDetailResponse
+
+// 그룹 상세 화면 UI 상태
+// - detail: GET /api/groups/{groupId}
+// - actionButton: buttonStatus + waitingCount를 VM에서 미리 매핑한 결과 (null이면 버튼 미표시)
+// - loading: 첫 진입/재시도 로딩
+// - error: 실패 메시지 (성공 시 null)
+data class GroupDetailUiState(
+    val detail: GroupDetailResponse? = null,
+    val actionButton: GroupDetailActionButton? = null,
+    val loading: Boolean = false,
+    val error: String? = null,
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupDetailUiState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/model/GroupDetailUiState.kt
@@ -4,7 +4,7 @@ import com.bookiibookii.bookiibookii.data.model.group.GroupDetailResponse
 
 // 그룹 상세 화면 UI 상태
 // - detail: GET /api/groups/{groupId}
-// - actionButton: buttonStatus + waitingCount를 VM에서 미리 매핑한 결과 (null이면 버튼 미표시)
+// - actionButton: buttonStatus + waitingCount를 VM에서 매핑한 결과 (null이면 버튼 미표시)
 // - loading: 첫 진입/재시도 로딩
 // - error: 실패 메시지 (성공 시 null)
 data class GroupDetailUiState(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupDestinations.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupDestinations.kt
@@ -9,7 +9,7 @@ object GroupDestinations {
     const val EDITOR = "editor?$ARG_GROUP_ID={$ARG_GROUP_ID}"
     const val JOIN_REQUESTS = "joinRequests/{$ARG_GROUP_ID}"
 
-    fun detail(groupId: String) = "detail/$groupId"
+    fun detail(groupId: Long) = "detail/$groupId"
 
     // groupId == null -> 생성, not null -> 수정
     fun editor(groupId: String? = null) =

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
@@ -66,7 +66,7 @@ fun GroupNavHost(
                 },
             ),
         ) {
-            // groupId는 SavedStateHandle을 통해 GroupDetailViewModel이 직접 수신 (navArgument 선언이 근거)
+            // groupId는 SavedStateHandle을 통해 GroupDetailViewModel이 직접 수신
             GroupDetailRoute(
                 onBack = { if (!navController.popBackStack()) onExit() },
                 // 액션 버튼(APPLY/MANAGE/CANCEL) 클릭 시 분기 네비게이션은 후속 작업

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
@@ -27,6 +27,9 @@ fun GroupNavHost(
             GroupSearchRoute(
                 // 백스택이 있으면 이전 화면으로, 없으면(홈에서 직접 진입) 그룹 도메인 밖으로 나감
                 onBack = { if (!navController.popBackStack()) onExit() },
+                onGroupClick = { groupId ->
+                    navController.navigate(GroupDestinations.detail(groupId))
+                },
             )
         }
         composable(
@@ -43,10 +46,10 @@ fun GroupNavHost(
                 // 백스택이 있으면 이전 화면(수정 진입: DETAIL)으로,
                 // 없으면(생성 진입: EDITOR가 시작점) 그룹 도메인 밖으로 나간다
                 onBack = { if (!navController.popBackStack()) onExit() },
-                // 생성 성공 → 그룹 상세로 이동. 편집 화면은 백스택에서 제거(뒤로 시 폼 재진입 방지)
+                // 생성 성공 → 그룹 상세로 이동. 편집 화면은 백스택에서 제거(뒤로가기 시 폼 재진입 방지)
                 onCreated = { groupId ->
                     if (groupId != null) {
-                        navController.navigate(GroupDestinations.detail(groupId.toString())) {
+                        navController.navigate(GroupDestinations.detail(groupId)) {
                             popUpTo(GroupDestinations.EDITOR) { inclusive = true }
                         }
                     } else if (!navController.popBackStack()) {
@@ -59,12 +62,16 @@ fun GroupNavHost(
             route = GroupDestinations.DETAIL,
             arguments = listOf(
                 navArgument(GroupDestinations.ARG_GROUP_ID) {
-                    type = NavType.StringType
+                    type = NavType.LongType
                 },
             ),
-        ) {
-            // groupId는 라우트로 전달되지만 GroupDetailScreen은 아직 정적 UI라 미사용 (상세 VM 연결은 후속)
-            GroupDetailScreen()
+        ) { backStackEntry ->
+            // 방어용 fallback 0L
+            val groupId = backStackEntry.arguments?.getLong(GroupDestinations.ARG_GROUP_ID) ?: 0L
+            GroupDetailScreen(
+                groupId = groupId,
+                onBack = { if (!navController.popBackStack()) onExit() },
+            )
         }
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
@@ -7,7 +7,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.bookiibookii.bookiibookii.group.ui.detail.GroupDetailScreen
+import com.bookiibookii.bookiibookii.group.ui.detail.GroupDetailRoute
 import com.bookiibookii.bookiibookii.group.ui.editor.GroupEditorRoute
 import com.bookiibookii.bookiibookii.group.ui.search.GroupSearchRoute
 
@@ -65,12 +65,12 @@ fun GroupNavHost(
                     type = NavType.LongType
                 },
             ),
-        ) { backStackEntry ->
-            // 방어용 fallback 0L
-            val groupId = backStackEntry.arguments?.getLong(GroupDestinations.ARG_GROUP_ID) ?: 0L
-            GroupDetailScreen(
-                groupId = groupId,
+        ) {
+            // groupId는 SavedStateHandle을 통해 GroupDetailViewModel이 직접 수신 (navArgument 선언이 근거)
+            GroupDetailRoute(
                 onBack = { if (!navController.popBackStack()) onExit() },
+                // 액션 버튼(APPLY/MANAGE/CANCEL) 클릭 시 분기 네비게이션은 후속 작업
+                onActionClick = {},
             )
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupCommentBottomSheet.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupCommentBottomSheet.kt
@@ -1,0 +1,389 @@
+package com.bookiibookii.bookiibookii.group.ui.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.common.DateUtils
+import com.bookiibookii.bookiibookii.data.model.group.CommentItem
+import com.bookiibookii.bookiibookii.data.model.group.CommentWriter
+import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 그룹 상세 화면의 댓글 바텀시트 (정적 UI)
+// - comments 비어 있음 → peek 상태 (헤더 + 입력 필드)
+// - comments 채워짐  → expanded 상태 (헤더 + 댓글 리스트 + 입력 필드)
+@Composable
+fun GroupCommentBottomSheetContent(
+    comments: List<CommentItem>,
+    totalCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
+            .background(BookiiBookiiTheme.colors.white)
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+            DragHandle()
+            CommentSheetHeader(count = totalCount)
+        }
+
+        // 댓글 리스트 (expanded 상태에서만 노출)
+        comments.forEach { comment ->
+            CommentRow(comment = comment)
+        }
+
+        CommentInputField()
+    }
+}
+
+// 드래그 핸들
+@Composable
+private fun DragHandle() {
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 44.dp, height = 4.dp)
+                .clip(BookiiBookiiTheme.shape.round50)
+                .background(BookiiBookiiTheme.colors.grey200),
+        )
+    }
+}
+
+// "댓글 N" 헤더 — count == 0이면 grey500, 양수면 main 컬러
+@Composable
+private fun CommentSheetHeader(count: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "댓글",
+            style = BookiiBookiiTheme.typography.semibold20,
+            color = BookiiBookiiTheme.colors.grey900,
+        )
+        Text(
+            text = "$count",
+            style = BookiiBookiiTheme.typography.regular16,
+            color = if (count > 0) {
+                BookiiBookiiTheme.colors.uiMain
+            } else {
+                BookiiBookiiTheme.colors.grey500
+            },
+        )
+    }
+}
+
+// 최상위 댓글 한 줄 (+ 답글 children 함께 렌더)
+@Composable
+private fun CommentRow(comment: CommentItem) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        ProfilePlaceholder(
+            modifier = Modifier.size(36.dp),
+            imageUrl = comment.writer.profileImage,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            CommentMetaAndBody(
+                nickname = comment.writer.name,
+                nicknameColor = BookiiBookiiTheme.colors.grey900,
+                createdAt = comment.createdAt,
+                secret = comment.secret,
+                content = comment.content,
+            )
+            // 답글 (children)
+            comment.children?.forEach { reply ->
+                ReplyRow(reply = reply)
+            }
+        }
+    }
+}
+
+// 답글 한 줄 — 닉네임을 main 컬러
+@Composable
+private fun ReplyRow(reply: CommentItem) {
+    Row(
+        modifier = Modifier.padding(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        ProfilePlaceholder(
+            modifier = Modifier.size(28.dp),
+            imageUrl = reply.writer.profileImage,
+        )
+        CommentMetaAndBody(
+            nickname = reply.writer.name,
+            nicknameColor = BookiiBookiiTheme.colors.uiMain,
+            createdAt = reply.createdAt,
+            secret = reply.secret,
+            content = reply.content,
+        )
+    }
+}
+
+// 닉네임 + 시간 + (secret이면) lock 아이콘 + 본문 — 댓글/답글 공용
+@Composable
+private fun CommentMetaAndBody(
+    nickname: String,
+    nicknameColor: androidx.compose.ui.graphics.Color,
+    createdAt: String,
+    secret: Boolean,
+    content: String,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = nickname,
+                style = BookiiBookiiTheme.typography.regular14,
+                color = nicknameColor,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = DateUtils.calculateTimeAgo(createdAt),
+                    style = BookiiBookiiTheme.typography.regular12,
+                    color = BookiiBookiiTheme.colors.grey500,
+                )
+                if (secret) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_lock),
+                        contentDescription = "비공개",
+                        tint = BookiiBookiiTheme.colors.grey500,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+        }
+        Text(
+            text = content,
+            style = BookiiBookiiTheme.typography.regular15,
+            color = BookiiBookiiTheme.colors.grey700,
+        )
+    }
+}
+
+// 입력 필드
+@Composable
+private fun CommentInputField() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .border(
+                width = 1.dp,
+                color = BookiiBookiiTheme.colors.grey300,
+                shape = RoundedCornerShape(20.dp),
+            )
+            .padding(horizontal = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            LockChip()
+            Text(
+                text = "텍스트 입력 전",
+                style = BookiiBookiiTheme.typography.regular16,
+                color = BookiiBookiiTheme.colors.grey500,
+            )
+        }
+        UploadChip()
+    }
+}
+
+// 입력 필드 좌측 잠금 칩
+@Composable
+private fun LockChip() {
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(BookiiBookiiTheme.shape.round16)
+            .background(BookiiBookiiTheme.colors.grey200),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_lock),
+            contentDescription = "비공개 토글",
+            tint = BookiiBookiiTheme.colors.grey500,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+// 입력 필드 우측 업로드 칩
+@Composable
+private fun UploadChip() {
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(BookiiBookiiTheme.shape.round50)
+            .background(BookiiBookiiTheme.colors.grey400),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_up),
+            contentDescription = "등록",
+            tint = BookiiBookiiTheme.colors.white,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Preview(widthDp = 412, showBackground = true, backgroundColor = 0xFFF6F6F6)
+@Composable
+private fun GroupCommentBottomSheetPeekPreview() {
+    BookiiPreview {
+        GroupCommentBottomSheetContent(
+            comments = emptyList(),
+            totalCount = 0,
+        )
+    }
+}
+
+@Preview(widthDp = 412, heightDp = 800, showBackground = true, backgroundColor = 0xFFF6F6F6)
+@Composable
+private fun GroupCommentBottomSheetExpandedPreview() {
+    BookiiPreview {
+        GroupCommentBottomSheetContent(
+            comments = previewComments,
+            totalCount = 30,
+        )
+    }
+}
+
+// Preview용 더미 댓글
+private val previewComments: List<CommentItem> = listOf(
+    CommentItem(
+        id = 1,
+        deleted = false,
+        secret = false,
+        content = "혹시 택배로도 교환 가능하실까용?",
+        parentId = null,
+        writer = CommentWriter(
+            userId = 1,
+            name = "kanghunsim",
+            profileImage = null,
+            role = "GUEST",
+        ),
+        createdAt = "2026-05-03T00:52:00Z",
+        children = listOf(
+            CommentItem(
+                id = 2,
+                deleted = false,
+                secret = true,
+                content = "어려울 거 같아요 죄송합니다 ㅠㅠ",
+                parentId = 1,
+                writer = CommentWriter(
+                    userId = 2,
+                    name = "noshel",
+                    profileImage = null,
+                    role = "HOST",
+                ),
+                createdAt = "2026-05-26T08:48:00Z",
+                children = null,
+            ),
+        ),
+    ),
+    CommentItem(
+        id = 3,
+        deleted = false,
+        secret = false,
+        content = "그럼 직접 방문 수령은 가능한가요?",
+        parentId = null,
+        writer = CommentWriter(
+            userId = 3,
+            name = "minjee_87",
+            profileImage = null,
+            role = "GUEST",
+        ),
+        createdAt = "2026-05-03T01:15:00Z",
+        children = listOf(
+            CommentItem(
+                id = 4,
+                deleted = false,
+                secret = true,
+                content = "네, 매장에 오시면 바로 교환 도와드릴게요!",
+                parentId = 3,
+                writer = CommentWriter(
+                    userId = 1,
+                    name = "kanghunsim",
+                    profileImage = null,
+                    role = "GUEST",
+                ),
+                createdAt = "2026-05-26T08:55:00Z",
+                children = null,
+            ),
+        ),
+    ),
+    CommentItem(
+        id = 5,
+        deleted = false,
+        secret = true,
+        content = "배송비는 누가 부담하나요?",
+        parentId = null,
+        writer = CommentWriter(
+            userId = 4,
+            name = "sohyun_park",
+            profileImage = null,
+            role = "GUEST",
+        ),
+        createdAt = "2026-05-03T01:40:00Z",
+        children = null,
+    ),
+    CommentItem(
+        id = 6,
+        deleted = false,
+        secret = true,
+        content = "반품은 어떻게 진행되나요?",
+        parentId = null,
+        writer = CommentWriter(
+            userId = 5,
+            name = "minseok_lee",
+            profileImage = null,
+            role = "GUEST",
+        ),
+        createdAt = "2026-05-03T02:15:00Z",
+        children = null,
+    ),
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupCommentBottomSheet.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupCommentBottomSheet.kt
@@ -1,61 +1,218 @@
 package com.bookiibookii.bookiibookii.group.ui.detail
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.common.DateUtils
+import com.bookiibookii.bookiibookii.common.showCustomToast
 import com.bookiibookii.bookiibookii.data.model.group.CommentItem
 import com.bookiibookii.bookiibookii.data.model.group.CommentWriter
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.bookiibookii.bookiibookii.group.model.GroupCommentUiState
+import com.bookiibookii.bookiibookii.group.vm.GroupCommentViewModel
+import com.bookiibookii.bookiibookii.onboarding.login.TokenManager
+import com.bookiibookii.bookiibookii.ui.component.DeletePopover
 import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
-// 그룹 상세 화면의 댓글 바텀시트 (정적 UI)
-// - comments 비어 있음 → peek 상태 (헤더 + 입력 필드)
-// - comments 채워짐  → expanded 상태 (헤더 + 댓글 리스트 + 입력 필드)
+// 댓글 바텀시트 — VM 주입/상태 수집/이벤트 구독 (stateful)
+// - expanded: GroupDetailRoute가 관리하는 sheet 확장 상태
+// - currentUserId: TokenManager에서 받아 Content로 내림 (백엔드 isMe 추가 시 제거 예정)
+// - eventFlow.ShowError → CommonToast (isSuccess = false → info 아이콘)
 @Composable
-fun GroupCommentBottomSheetContent(
-    comments: List<CommentItem>,
-    totalCount: Int,
+fun GroupCommentBottomSheetRoute(
+    expanded: Boolean = false,
+    onExpand: () -> Unit = {},
+    viewModel: GroupCommentViewModel = viewModel(),
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    val uiState by viewModel.state.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val currentUserId = remember { TokenManager.getUserId(context) }
+
+    LaunchedEffect(Unit) {
+        viewModel.eventFlow.collect { event ->
+            when (event) {
+                is GroupCommentViewModel.Event.ShowError -> {
+                    context.showCustomToast(event.message, isSuccess = false)
+                }
+            }
+        }
+    }
+
+    // 답글 모드 진입
+    // replyRequestId 기반이라 같은 댓글 재클릭에도 재실행
+    LaunchedEffect(uiState.replyRequestId) {
+        if (uiState.replyRequestId > 0 && uiState.replyTargetId != null) {
+            onExpand()
+        }
+    }
+
+    GroupCommentBottomSheetContent(
+        uiState = uiState,
+        currentUserId = currentUserId,
+        expanded = expanded,
+        onInputClick = onExpand,
+        onStartReply = viewModel::startReply,
+        onDelete = viewModel::delete,
+        onDraftChange = viewModel::onDraftChange,
+        onToggleSecret = viewModel::toggleSecret,
+        onSubmit = viewModel::submit,
+        modifier = modifier,
+    )
+}
+
+// 그룹 상세 화면의 댓글 바텀시트
+// - expanded == false → drag handle + 헤더 + 입력 필드만 보임
+// - expanded == true → drag handle + 헤더 + 댓글 리스트 + 입력 필드
+// - 입력 필드는 Box.align(BottomCenter) + imePadding으로 키보드 위에 항상 떠 있음 (댓글 위에 오버레이)
+@Composable
+fun GroupCommentBottomSheetContent(
+    uiState: GroupCommentUiState,
+    currentUserId: Long?,
+    expanded: Boolean,
+    onInputClick: () -> Unit,
+    onStartReply: (parentId: Long, nickname: String) -> Unit,
+    onDelete: (commentId: Long) -> Unit,
+    onDraftChange: (String) -> Unit,
+    onToggleSecret: () -> Unit,
+    onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+    val density = LocalDensity.current
+    val imeBottom = with(density) { WindowInsets.ime.getBottom(density).toDp() }
+
+    // 답글 모드 진입 시 대상 부모 댓글로 스크롤 (입력창/키보드 위에 보이도록)
+    // key에 imeBottom 포함 → 키보드가 떠서 하단 여백이 생긴 뒤에도 다시 스크롤 (마지막 댓글도 올라감)
+    // replyRequestId 기반이라 같은 댓글 재클릭에도 다시 스크롤
+    LaunchedEffect(uiState.replyRequestId, imeBottom) {
+        val targetId = uiState.replyTargetId ?: return@LaunchedEffect
+        val targetIndex = uiState.comments.indexOfFirst { it.id == targetId }
+        if (targetIndex >= 0) {
+            listState.animateScrollToItem(targetIndex)
+        }
+    }
+
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
-            .background(BookiiBookiiTheme.colors.white)
-            .padding(horizontal = 16.dp, vertical = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
+            .background(BookiiBookiiTheme.colors.white),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
-            DragHandle()
-            CommentSheetHeader(count = totalCount)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+                DragHandle()
+                CommentSheetHeader(count = uiState.totalCount)
+            }
+            if (expanded) {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    contentPadding = PaddingValues(bottom = 56.dp + imeBottom),
+                ) {
+                    items(uiState.comments, key = { it.id }) { comment ->
+                        CommentRow(
+                            comment = comment,
+                            currentUserId = currentUserId,
+                            onStartReply = onStartReply,
+                            onDelete = onDelete,
+                        )
+                    }
+                }
+            }
         }
-
-        // 댓글 리스트 (expanded 상태에서만 노출)
-        comments.forEach { comment ->
-            CommentRow(comment = comment)
-        }
-
-        CommentInputField()
+        // 입력 필드 오버레이 — 입력창만 키보드 위로
+        CommentInputField(
+            draft = uiState.draft,
+            draftSecret = uiState.draftSecret,
+            mentionNickname = uiState.mentionNickname,
+            replyRequestId = uiState.replyRequestId,
+            submitting = uiState.submitting,
+            expanded = expanded,
+            onInputClick = onInputClick,
+            onDraftChange = onDraftChange,
+            onToggleSecret = onToggleSecret,
+            onSubmit = onSubmit,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .imePadding()
+                .background(BookiiBookiiTheme.colors.white)
+                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 24.dp),
+        )
     }
 }
 
@@ -102,56 +259,120 @@ private fun CommentSheetHeader(count: Int) {
     }
 }
 
-// 최상위 댓글 한 줄 (+ 답글 children 함께 렌더)
+// 최상위 댓글 + 답글들
+// 답글 short-tap도 부모 댓글에 답글 (트리 2단계 제약)
 @Composable
-private fun CommentRow(comment: CommentItem) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(4.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        ProfilePlaceholder(
-            modifier = Modifier.size(36.dp),
-            imageUrl = comment.writer.profileImage,
+private fun CommentRow(
+    comment: CommentItem,
+    currentUserId: Long?,
+    onStartReply: (parentId: Long, nickname: String) -> Unit,
+    onDelete: (commentId: Long) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // 최상위 댓글
+        CommentItemRow(
+            comment = comment,
+            isMine = isMine(currentUserId, comment.writer.userId),
+            profileSize = 36.dp,
+            indentStart = 0.dp,
+            onTap = { onStartReply(comment.id, comment.writer.name) },
+            onDelete = { onDelete(comment.id) },
         )
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // 답글
+        comment.children?.forEach { reply ->
+            CommentItemRow(
+                comment = reply,
+                isMine = isMine(currentUserId, reply.writer.userId),
+                profileSize = 28.dp,
+                indentStart = 52.dp,
+                onTap = { onStartReply(comment.id, reply.writer.name) },
+                onDelete = { onDelete(reply.id) },
+            )
+        }
+    }
+}
+
+private fun isMine(currentUserId: Long?, writerId: Long): Boolean =
+    currentUserId != null && writerId == currentUserId
+
+// 댓글 한 줄
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun CommentItemRow(
+    comment: CommentItem,
+    isMine: Boolean,
+    profileSize: Dp,
+    indentStart: Dp,
+    onTap: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    var showPopover by remember { mutableStateOf(false) }
+    var rowSize by remember { mutableStateOf(IntSize.Zero) }
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    Box(modifier = Modifier.padding(start = indentStart)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .onSizeChanged { rowSize = it }
+                .background(
+                    if (isPressed) BookiiBookiiTheme.colors.grey100 else Color.Transparent,
+                )
+                .combinedClickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = onTap,
+                    // 본인 댓글에만 long-press 허용. 타인은 null이라 무반응
+                    onLongClick = if (isMine) ({ showPopover = true }) else null,
+                )
+                .padding(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            ProfilePlaceholder(
+                modifier = Modifier.size(profileSize),
+                imageUrl = comment.writer.profileImage,
+            )
             CommentMetaAndBody(
                 nickname = comment.writer.name,
-                nicknameColor = BookiiBookiiTheme.colors.grey900,
+                nicknameColor = nicknameColorFor(comment.writer.role),
                 createdAt = comment.createdAt,
                 secret = comment.secret,
                 content = comment.content,
             )
-            // 답글 (children)
-            comment.children?.forEach { reply ->
-                ReplyRow(reply = reply)
+        }
+        if (showPopover) {
+            val density = LocalDensity.current
+            // 행 기준 왼쪽 208dp 들여쓰고 오른쪽 28dp 여백 → popover 너비 = 행너비 - 208 - 28
+            // 디자인 컨펌 받고 수정
+            val popoverWidth = with(density) { rowSize.width.toDp() } - 208.dp - 28.dp
+            Popup(
+                alignment = Alignment.TopStart,
+                offset = IntOffset(
+                    x = with(density) { 208.dp.roundToPx() },
+                    y = rowSize.height,
+                ),
+                onDismissRequest = { showPopover = false },
+                properties = PopupProperties(focusable = true),
+            ) {
+                DeletePopover(
+                    onDeleteClick = {
+                        onDelete()
+                        showPopover = false
+                    },
+                    modifier = Modifier.width(popoverWidth),
+                )
             }
         }
     }
 }
 
-// 답글 한 줄 — 닉네임을 main 컬러
+// 작성자 role에 따른 닉네임 색상 — HOST 강조
 @Composable
-private fun ReplyRow(reply: CommentItem) {
-    Row(
-        modifier = Modifier.padding(4.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        ProfilePlaceholder(
-            modifier = Modifier.size(28.dp),
-            imageUrl = reply.writer.profileImage,
-        )
-        CommentMetaAndBody(
-            nickname = reply.writer.name,
-            nicknameColor = BookiiBookiiTheme.colors.uiMain,
-            createdAt = reply.createdAt,
-            secret = reply.secret,
-            content = reply.content,
-        )
-    }
+private fun nicknameColorFor(role: String): Color = when (role) {
+    "HOST" -> BookiiBookiiTheme.colors.uiMain
+    else -> BookiiBookiiTheme.colors.grey900   // GUEST / NONE / 그 외
 }
 
 // 닉네임 + 시간 + (secret이면) lock 아이콘 + 본문 — 댓글/답글 공용
@@ -200,65 +421,162 @@ private fun CommentMetaAndBody(
     }
 }
 
-// 입력 필드
+// 입력 필드 — BasicTextField + 멘션 prefix + 자동 포커스(expand 진입 시)
+// 멘션 prefix 한글자라도 깨지면 초기화
 @Composable
-private fun CommentInputField() {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(48.dp)
-            .clip(RoundedCornerShape(20.dp))
-            .border(
-                width = 1.dp,
-                color = BookiiBookiiTheme.colors.grey300,
-                shape = RoundedCornerShape(20.dp),
-            )
-            .padding(horizontal = 4.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+private fun CommentInputField(
+    draft: String,
+    draftSecret: Boolean,
+    mentionNickname: String?,
+    replyRequestId: Int,
+    submitting: Boolean,
+    expanded: Boolean,
+    onInputClick: () -> Unit,
+    onDraftChange: (String) -> Unit,
+    onToggleSecret: () -> Unit,
+    onSubmit: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    val keyboard = LocalSoftwareKeyboardController.current
+    val transformation = rememberMentionVisualTransformation(mentionNickname)
+
+    // 커서 위치 제어를 위해 TextFieldValue 사용
+    var fieldValue by remember { mutableStateOf(TextFieldValue(draft, TextRange(draft.length))) }
+    // draft가 외부에서 바뀌면(답글 진입 "@닉네임 ", submit 클리어 등) 동기화 + 커서를 끝으로
+    // 답글 진입 시 커서 "@닉네임 " prefix 바로 뒤
+    LaunchedEffect(draft) {
+        if (fieldValue.text != draft) {
+            fieldValue = fieldValue.copy(text = draft, selection = TextRange(draft.length))
+        }
+    }
+
+    // Sheet expand 시에는 자동 키보드 X — 사용자가 직접 입력 필드 탭해야 활성
+    // Sheet collapse 시에는 활성된 키보드 내려감
+    LaunchedEffect(expanded) {
+        if (!expanded) {
+            keyboard?.hide()
+        }
+    }
+
+    // 답글 모드 진입 시 자동 focus
+    // replyRequestId 기반이라 같은 댓글을 다시 클릭해도 매번 재실행됨
+    LaunchedEffect(replyRequestId) {
+        if (replyRequestId > 0 && mentionNickname != null) {
+            focusRequester.requestFocus()
+            keyboard?.show()
+        }
+    }
+
+    // 댓글 작성 직후 키보드 내려감 — 작성 성공/실패와 무관
+    val submitAndHide: () -> Unit = {
+        onSubmit()
+        keyboard?.hide()
+    }
+
+    // 제출 가능 여부 — 멘션 prefix만 남은 경우(또는 빈 텍스트)는 비활성
+    val effectiveContent = if (mentionNickname != null) {
+        draft.removePrefix("@$mentionNickname ").trim()
+    } else {
+        draft.trim()
+    }
+    val canSubmit = effectiveContent.isNotEmpty() && !submitting
+
+    // 외부 modifier가 background/padding/imePadding을 책임 (중복 X)
+    Box(modifier = modifier) {
         Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(BookiiBookiiTheme.colors.white)
+                .border(
+                    width = 1.dp,
+                    color = BookiiBookiiTheme.colors.grey300,
+                    shape = RoundedCornerShape(20.dp),
+                )
+                .padding(horizontal = 4.dp, vertical = 4.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            LockChip()
-            Text(
-                text = "텍스트 입력 전",
-                style = BookiiBookiiTheme.typography.regular16,
-                color = BookiiBookiiTheme.colors.grey500,
+            LockChip(active = draftSecret, onClick = onToggleSecret)
+            BasicTextField(
+                value = fieldValue,
+                onValueChange = { newValue ->
+                    fieldValue = newValue
+                    // text가 실제로 바뀐 경우에만 VM에 통지
+                    if (newValue.text != draft) onDraftChange(newValue.text)
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .focusRequester(focusRequester),
+                visualTransformation = transformation,
+                textStyle = BookiiBookiiTheme.typography.regular16.copy(
+                    color = BookiiBookiiTheme.colors.grey900,
+                ),
+                cursorBrush = SolidColor(BookiiBookiiTheme.colors.uiMain),
+                maxLines = 4,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                keyboardActions = KeyboardActions(onSend = { if (canSubmit) submitAndHide() }),
+                decorationBox = { innerTextField ->
+                    Box {
+                        if (draft.isEmpty()) {
+                            Text(
+                                text = "텍스트 입력 전",
+                                style = BookiiBookiiTheme.typography.regular16,
+                                color = BookiiBookiiTheme.colors.grey500,
+                            )
+                        }
+                        innerTextField()
+                    }
+                },
+            )
+            UploadChip(enabled = canSubmit, onClick = submitAndHide)
+        }
+        // Peek 상태에서는 입력 필드 영역의 모든 클릭을 가로채서 expand만 트리거
+        // BasicTextField/Chip들로 클릭이 닿지 않게 함
+        if (!expanded) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .clickable(onClick = onInputClick),
             )
         }
-        UploadChip()
     }
 }
 
-// 입력 필드 좌측 잠금 칩
+// 입력 필드 좌측 잠금 칩 — secret 토글 (active일 때 main 컬러)
 @Composable
-private fun LockChip() {
+private fun LockChip(active: Boolean, onClick: () -> Unit) {
+    val bg = if (active) BookiiBookiiTheme.colors.uiMain else BookiiBookiiTheme.colors.grey200
+    val tint = if (active) BookiiBookiiTheme.colors.white else BookiiBookiiTheme.colors.grey500
     Box(
         modifier = Modifier
             .size(40.dp)
             .clip(BookiiBookiiTheme.shape.round16)
-            .background(BookiiBookiiTheme.colors.grey200),
+            .background(bg)
+            .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             painter = painterResource(R.drawable.ic_lock),
             contentDescription = "비공개 토글",
-            tint = BookiiBookiiTheme.colors.grey500,
+            tint = tint,
             modifier = Modifier.size(24.dp),
         )
     }
 }
 
-// 입력 필드 우측 업로드 칩
+// 입력 필드 우측 업로드 칩 — 제출 가능 시 main 컬러로 활성화
 @Composable
-private fun UploadChip() {
+private fun UploadChip(enabled: Boolean, onClick: () -> Unit) {
+    val bg = if (enabled) BookiiBookiiTheme.colors.uiMain else BookiiBookiiTheme.colors.grey400
     Box(
         modifier = Modifier
             .size(40.dp)
             .clip(BookiiBookiiTheme.shape.round50)
-            .background(BookiiBookiiTheme.colors.grey400),
+            .background(bg)
+            .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
@@ -270,24 +588,65 @@ private fun UploadChip() {
     }
 }
 
-@Preview(widthDp = 412, showBackground = true, backgroundColor = 0xFFF6F6F6)
+// 멘션 prefix "@{nickname} "를 main 컬러로 표시하는 VisualTransformation
+@Composable
+private fun rememberMentionVisualTransformation(mentionNickname: String?): VisualTransformation {
+    val mainColor = BookiiBookiiTheme.colors.uiMain
+    return remember(mentionNickname, mainColor) {
+        if (mentionNickname == null) {
+            VisualTransformation.None
+        } else {
+            val prefix = "@$mentionNickname "
+            VisualTransformation { text ->
+                val raw = text.text
+                val styled = buildAnnotatedString {
+                    if (raw.startsWith(prefix)) {
+                        withStyle(SpanStyle(color = mainColor)) {
+                            append(prefix)
+                        }
+                        append(raw.substring(prefix.length))
+                    } else {
+                        append(raw)
+                    }
+                }
+                TransformedText(styled, OffsetMapping.Identity)
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 412, heightDp = 170, showBackground = true, backgroundColor = 0xFFF6F6F6)
 @Composable
 private fun GroupCommentBottomSheetPeekPreview() {
     BookiiPreview {
         GroupCommentBottomSheetContent(
-            comments = emptyList(),
-            totalCount = 0,
+            uiState = GroupCommentUiState(comments = emptyList(), totalCount = 0),
+            currentUserId = null,
+            expanded = false,
+            onInputClick = {},
+            onStartReply = { _, _ -> },
+            onDelete = {},
+            onDraftChange = {},
+            onToggleSecret = {},
+            onSubmit = {},
         )
     }
 }
 
-@Preview(widthDp = 412, heightDp = 800, showBackground = true, backgroundColor = 0xFFF6F6F6)
+@Preview(widthDp = 412, heightDp = 544, showBackground = true, backgroundColor = 0xFFF6F6F6)
 @Composable
 private fun GroupCommentBottomSheetExpandedPreview() {
     BookiiPreview {
         GroupCommentBottomSheetContent(
-            comments = previewComments,
-            totalCount = 30,
+            uiState = GroupCommentUiState(comments = previewComments, totalCount = 30),
+            currentUserId = 2L,
+            expanded = true,
+            onInputClick = {},
+            onStartReply = { _, _ -> },
+            onDelete = {},
+            onDraftChange = {},
+            onToggleSecret = {},
+            onSubmit = {},
         )
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
@@ -1,15 +1,19 @@
 package com.bookiibookii.bookiibookii.group.ui.detail
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -21,12 +25,17 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -49,6 +58,11 @@ import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
 // 그룹 상세 화면 — VM 주입/상태 수집 (stateful)
+// 댓글 sheet는 BottomSheetScaffold 대신 직접 Box stack으로 구현:
+//   - 본문은 항상 bottom 170dp (peek 높이) padding을 받아 sheet 아래로 가려지지 않음
+//   - sheet 높이 3단계: peek 170 / expanded 544 / keyboard 580
+//   - swipe up/down으로 expand 토글 (누적 drag 50dp 초과 시)
+//   - 키보드: sheet는 안 올리고 높이만 580으로 키움 + 입력창만 imePadding (입력창 위 댓글 1개 노출)
 @Composable
 fun GroupDetailRoute(
     onBack: () -> Unit,
@@ -56,24 +70,69 @@ fun GroupDetailRoute(
     viewModel: GroupDetailViewModel = viewModel(),
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
-    GroupDetailScreen(
-        uiState = uiState,
-        onBack = onBack,
-        onActionClick = onActionClick,
-        onRetry = viewModel::retry,
+    var expanded by remember { mutableStateOf(false) }
+    // 키보드 표시 여부 — 키보드 뜨면 sheet 높이를 키워 입력창 위 댓글 공간 확보
+    val imeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
+    // 3단계 높이: keyboard(580) > expanded(544) > peek(170)
+    // sheet 자체엔 imePadding 안 줌 (화면 하단 고정). 입력창만 imePadding으로 키보드 위에 붙고,
+    // 높이를 키워서 그 위로 댓글이 보이게 함
+    val sheetHeight by animateDpAsState(
+        targetValue = when {
+            imeVisible -> 600.dp
+            expanded -> 544.dp
+            else -> 170.dp
+        },
+        label = "sheetHeight",
     )
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        GroupDetailScreen(
+            uiState = uiState,
+            onBack = onBack,
+            onActionClick = onActionClick,
+            onRetry = viewModel::retry,
+            // 본문 하단은 항상 peek 170dp만큼 padding (sheet 아래로 가지 않게)
+            modifier = Modifier.padding(bottom = 170.dp),
+        )
+        GroupCommentBottomSheetRoute(
+            expanded = expanded,
+            onExpand = { expanded = true },
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(sheetHeight)
+                .pointerInput(Unit) {
+                    // 누적 drag가 50dp 임계 넘으면 토글. drag 끝에서 결정
+                    val triggerPx = 50.dp.toPx()
+                    var totalDrag = 0f
+                    detectVerticalDragGestures(
+                        onDragStart = { totalDrag = 0f },
+                        onDragEnd = {
+                            when {
+                                totalDrag < -triggerPx -> expanded = true   // swipe up
+                                totalDrag > triggerPx -> expanded = false   // swipe down
+                            }
+                        },
+                        onDragCancel = { totalDrag = 0f },
+                    ) { _, dragAmount ->
+                        totalDrag += dragAmount
+                    }
+                },
+        )
+    }
 }
 
-// 그룹 상세 화면 (stateless: 상태·콜백을 파라미터로 받음)
+// 그룹 상세 화면
 @Composable
 fun GroupDetailScreen(
     uiState: GroupDetailUiState,
     onBack: () -> Unit,
     onActionClick: () -> Unit,
     onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(BookiiBookiiTheme.colors.uiBg),
     ) {
@@ -151,7 +210,6 @@ private fun GroupDetailContent(
             )
             GroupDetailDescriptionCard(
                 title = "그룹 규칙",
-                // rules는 응답에서 content가 항상 채워짐 (프리셋 태그도 백엔드가 표시 텍스트 제공)
                 body = detail.rules.joinToString("\n") { it.content },
             )
             GroupDetailMembersCard(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
@@ -44,6 +44,7 @@ import com.bookiibookii.bookiibookii.group.vm.GroupDetailViewModel
 import com.bookiibookii.bookiibookii.ui.component.BookCover
 import com.bookiibookii.bookiibookii.ui.component.CardButton
 import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
+import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
@@ -218,6 +219,7 @@ private fun GroupDetailInfoSection(
             nickname = detail.hostNickname,
             groupName = detail.groupName,
             bookImage = detail.bookImage,
+            hostProfileImageUrl = detail.hostProfileImageUrl,
         )
         // buttonStatus가 TRACKER/FULL/unknown이면 actionButton이 null → 버튼 미표시
         if (actionButton != null) {
@@ -241,6 +243,7 @@ private fun GroupDetailBookInfo(
     nickname: String,
     groupName: String,
     bookImage: String?,
+    hostProfileImageUrl: String?,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -302,11 +305,9 @@ private fun GroupDetailBookInfo(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Box(
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clip(BookiiBookiiTheme.shape.round50)
-                            .background(BookiiBookiiTheme.colors.uiBg),
+                    ProfilePlaceholder(
+                        modifier = Modifier.size(20.dp),
+                        imageUrl = hostProfileImageUrl,
                     )
                     Text(
                         text = nickname,
@@ -497,12 +498,9 @@ private fun ParticipantSlotRow(slot: ParticipantSlot) {
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // 프로필 이미지 자리 (이미지 로딩은 후속 작업)
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(BookiiBookiiTheme.shape.round16)
-                .background(BookiiBookiiTheme.colors.uiBg),
+        ProfilePlaceholder(
+            modifier = Modifier.size(40.dp),
+            imageUrl = slot.profileImageUrl,
         )
         when (slot.role) {
             "HOST" -> Row(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
@@ -2,6 +2,7 @@ package com.bookiibookii.bookiibookii.group.ui.detail
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,11 +14,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,19 +32,44 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.data.model.group.GroupDetailResponse
+import com.bookiibookii.bookiibookii.data.model.group.GroupRule
+import com.bookiibookii.bookiibookii.data.model.group.ParticipantSlot
+import com.bookiibookii.bookiibookii.group.model.GroupDetailActionButton
+import com.bookiibookii.bookiibookii.group.model.GroupDetailUiState
+import com.bookiibookii.bookiibookii.group.vm.GroupDetailViewModel
+import com.bookiibookii.bookiibookii.ui.component.BookCover
 import com.bookiibookii.bookiibookii.ui.component.CardButton
 import com.bookiibookii.bookiibookii.ui.component.CardButtonStyle
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
-// 그룹 상세 화면
-// groupId: 라우트로 전달받는 그룹 식별자 (현재는 미사용, 다음 VM 연결 단계에서 사용)
-@Suppress("UNUSED_PARAMETER")
+// 그룹 상세 화면 — VM 주입/상태 수집 (stateful)
+@Composable
+fun GroupDetailRoute(
+    onBack: () -> Unit,
+    onActionClick: () -> Unit,
+    viewModel: GroupDetailViewModel = viewModel(),
+) {
+    val uiState by viewModel.state.collectAsStateWithLifecycle()
+    GroupDetailScreen(
+        uiState = uiState,
+        onBack = onBack,
+        onActionClick = onActionClick,
+        onRetry = viewModel::retry,
+    )
+}
+
+// 그룹 상세 화면 (stateless: 상태·콜백을 파라미터로 받음)
 @Composable
 fun GroupDetailScreen(
-    groupId: Long,
+    uiState: GroupDetailUiState,
     onBack: () -> Unit,
+    onActionClick: () -> Unit,
+    onRetry: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -49,35 +77,87 @@ fun GroupDetailScreen(
             .background(BookiiBookiiTheme.colors.uiBg),
     ) {
         GroupDetailHeader(onBack = onBack)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            when {
+                uiState.loading && uiState.detail == null -> {
+                    CircularProgressIndicator(color = BookiiBookiiTheme.colors.uiMain)
+                }
+
+                uiState.error != null && uiState.detail == null -> {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text = uiState.error,
+                            style = BookiiBookiiTheme.typography.regular14,
+                            color = BookiiBookiiTheme.colors.grey500,
+                        )
+                        Text(
+                            text = "다시 시도",
+                            style = BookiiBookiiTheme.typography.medium14,
+                            color = BookiiBookiiTheme.colors.uiMain,
+                            modifier = Modifier.clickable(onClick = onRetry),
+                        )
+                    }
+                }
+
+                uiState.detail != null -> {
+                    GroupDetailContent(
+                        detail = uiState.detail,
+                        actionButton = uiState.actionButton,
+                        onActionClick = onActionClick,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// 성공 상태 본문 (스크롤)
+@Composable
+private fun GroupDetailContent(
+    detail: GroupDetailResponse,
+    actionButton: GroupDetailActionButton?,
+    onActionClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+    ) {
+        GroupDetailInfoSection(
+            detail = detail,
+            actionButton = actionButton,
+            onActionClick = onActionClick,
+        )
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f)
-                .verticalScroll(rememberScrollState()),
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            GroupDetailInfoSection()
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                GroupDetailDescriptionCard(
-                    title = "그룹 소개",
-                    body = "고전 문학이랑 교환 원해요. 민음사 전집 도장 깨기 중입니다...",
-                    exchangePlaceName = "숭실대학교정보과학관",
-                    exchangePlaceAddress = "서울 동작구 사당로 50",
-                )
-                GroupDetailDescriptionCard(
-                    title = "그룹 규칙",
-                    body = "책을 자유롭게 읽어주세요.\n독서카드 많이많이 올려주셨으면 좋겠어요!",
-                )
-                GroupDetailMembersCard(
-                    currentCount = 1,
-                    maxCount = 2,
-                    hostName = "noshel",
-                )
-            }
+            GroupDetailDescriptionCard(
+                title = "그룹 소개",
+                body = detail.groupComment.orEmpty(),
+                exchangePlaceName = detail.placeName,
+                exchangePlaceAddress = detail.address,
+            )
+            GroupDetailDescriptionCard(
+                title = "그룹 규칙",
+                // rules는 응답에서 content가 항상 채워짐 (프리셋 태그도 백엔드가 표시 텍스트 제공)
+                body = detail.rules.joinToString("\n") { it.content },
+            )
+            GroupDetailMembersCard(
+                matchedCount = detail.matchedCount,
+                maxCapacity = detail.maxCapacity,
+                participantSlots = detail.participantSlots,
+            )
         }
     }
 }
@@ -115,9 +195,13 @@ private fun GroupDetailHeader(onBack: () -> Unit) {
     }
 }
 
-// 그룹 정보 카드 + 하단 버튼
+// 그룹 정보 카드 + 하단 액션 버튼
 @Composable
-private fun GroupDetailInfoSection() {
+private fun GroupDetailInfoSection(
+    detail: GroupDetailResponse,
+    actionButton: GroupDetailActionButton?,
+    onActionClick: () -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -126,20 +210,24 @@ private fun GroupDetailInfoSection() {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         GroupDetailBookInfo(
-            title = "살인자의 기억법",
-            author = "김영하",
-            category = "한국소설",
-            exchangeType = "직접",
-            expectedDays = 7,
-            nickname = "닉네임",
-            groupName = "그룹명",
+            title = detail.title,
+            author = detail.author,
+            category = detail.genre,
+            exchangeType = tradeTypeLabel(detail.tradeType),
+            expectedDays = detail.readingPeriod,
+            nickname = detail.hostNickname,
+            groupName = detail.groupName,
+            bookImage = detail.bookImage,
         )
-        CardButton(
-            text = "참여 신청하기",
-            style = CardButtonStyle.Main,
-            onClick = {},
-            modifier = Modifier.fillMaxWidth(),
-        )
+        // buttonStatus가 TRACKER/FULL/unknown이면 actionButton이 null → 버튼 미표시
+        if (actionButton != null) {
+            CardButton(
+                text = actionButton.text,
+                style = actionButton.style,
+                onClick = onActionClick,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
 
@@ -152,16 +240,15 @@ private fun GroupDetailBookInfo(
     expectedDays: Int,
     nickname: String,
     groupName: String,
+    bookImage: String?,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .size(width = 72.dp, height = 100.dp)
-                .clip(BookiiBookiiTheme.shape.round8)
-                .background(BookiiBookiiTheme.colors.uiBg),
+        BookCover(
+            imageUrl = bookImage,
+            modifier = Modifier.size(width = 72.dp, height = 100.dp),
         )
         Column(
             modifier = Modifier
@@ -363,9 +450,9 @@ private fun DashedDivider(
 // 참여 멤버 카드
 @Composable
 private fun GroupDetailMembersCard(
-    currentCount: Int,
-    maxCount: Int,
-    hostName: String,
+    matchedCount: Int,
+    maxCapacity: Int,
+    participantSlots: List<ParticipantSlot>,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -388,7 +475,7 @@ private fun GroupDetailMembersCard(
                     color = BookiiBookiiTheme.colors.grey900,
                 )
                 Text(
-                    text = "$currentCount/$maxCount 명",
+                    text = "$matchedCount/$maxCapacity 명",
                     style = BookiiBookiiTheme.typography.regular14,
                     color = BookiiBookiiTheme.colors.uiMain,
                 )
@@ -396,48 +483,52 @@ private fun GroupDetailMembersCard(
             HorizontalDivider(thickness = 1.dp, color = BookiiBookiiTheme.colors.grey100)
         }
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            // 호스트
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            participantSlots.forEach { slot ->
+                ParticipantSlotRow(slot = slot)
+            }
+        }
+    }
+}
+
+// 슬롯 한 줄 (HOST / GUEST / EMPTY)
+@Composable
+private fun ParticipantSlotRow(slot: ParticipantSlot) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // 프로필 이미지 자리 (이미지 로딩은 후속 작업)
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(BookiiBookiiTheme.shape.round16)
+                .background(BookiiBookiiTheme.colors.uiBg),
+        )
+        when (slot.role) {
+            "HOST" -> Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(40.dp)
-                        .clip(BookiiBookiiTheme.shape.round16)
-                        .background(BookiiBookiiTheme.colors.uiBg),
+                Text(
+                    text = slot.nickname.orEmpty(),
+                    style = BookiiBookiiTheme.typography.regular14,
+                    color = BookiiBookiiTheme.colors.grey900,
                 )
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = hostName,
-                        style = BookiiBookiiTheme.typography.regular14,
-                        color = BookiiBookiiTheme.colors.grey900,
-                    )
-                    GroupDetailHostChip()
-                }
+                GroupDetailHostChip()
             }
-            // 모집 중 빈 자리
-            repeat(maxCount - currentCount) {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(BookiiBookiiTheme.shape.round16)
-                            .background(BookiiBookiiTheme.colors.uiBg),
-                    )
-                    Text(
-                        text = "모집 중",
-                        style = BookiiBookiiTheme.typography.regular14,
-                        color = BookiiBookiiTheme.colors.grey600,
-                    )
-                }
-            }
+
+            "EMPTY" -> Text(
+                text = "모집 중",
+                style = BookiiBookiiTheme.typography.regular14,
+                color = BookiiBookiiTheme.colors.grey600,
+            )
+
+            // GUEST 등 그 외 — 닉네임만 표시
+            else -> Text(
+                text = slot.nickname.orEmpty(),
+                style = BookiiBookiiTheme.typography.regular14,
+                color = BookiiBookiiTheme.colors.grey900,
+            )
         }
     }
 }
@@ -458,10 +549,72 @@ private fun GroupDetailHostChip() {
     }
 }
 
+// tradeType 코드 → 표시 라벨 (Search 화면과 동일 규칙)
+private fun tradeTypeLabel(tradeType: String): String = when (tradeType) {
+    "DIRECT" -> "직접"
+    "DELIVERY" -> "택배"
+    else -> ""
+}
+
 @Preview(widthDp = 412, heightDp = 917, showBackground = true)
 @Composable
 private fun GroupDetailScreenPreview() {
     BookiiPreview {
-        GroupDetailScreen(groupId = 0L, onBack = {})
+        GroupDetailScreen(
+            uiState = GroupDetailUiState(
+                detail = GroupDetailResponse(
+                    groupId = 12,
+                    groupStatus = "RECRUITING",
+                    isHost = true,
+                    tradeType = "DELIVERY",
+                    placeName = "자취방",
+                    address = "서울특별시",
+                    title = "녹나무의 여신",
+                    bookImage = null,
+                    author = "히가시노 게이고",
+                    genre = "기타",
+                    readingPeriod = 14,
+                    matchedCount = 1,
+                    maxCapacity = 2,
+                    waitingCount = 0,
+                    isHot = false,
+                    createdAt = "2026. 05. 24.",
+                    startDate = null,
+                    hostNickname = "이중희카카오",
+                    hostProfileImageUrl = null,
+                    groupComment = "잠수는 안됩니다",
+                    groupName = "안녕하세요",
+                    rules = listOf(
+                        GroupRule(tag = "MEMO", content = "책에 직접 코멘트를 남겨요!"),
+                        GroupRule(tag = "CUSTOM", content = "책을 소중히 다룹시다"),
+                        GroupRule(tag = "CUSTOM", content = "반갑습니다"),
+                    ),
+                    participantSlots = listOf(
+                        ParticipantSlot(
+                            nickname = "이중희카카오",
+                            profileImageUrl = null,
+                            role = "HOST",
+                            isMe = true,
+                        ),
+                        ParticipantSlot(
+                            nickname = null,
+                            profileImageUrl = null,
+                            role = "EMPTY",
+                            isMe = false,
+                        ),
+                    ),
+                    buttonStatus = "MANAGE",
+                ),
+                actionButton = GroupDetailActionButton(
+                    text = "참여 요청 관리 0",
+                    style = CardButtonStyle.Main,
+                ),
+                loading = false,
+                error = null,
+            ),
+            onBack = {},
+            onActionClick = {},
+            onRetry = {},
+        )
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
@@ -36,14 +36,19 @@ import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
 // 그룹 상세 화면
+// groupId: 라우트로 전달받는 그룹 식별자 (현재는 미사용, 다음 VM 연결 단계에서 사용)
+@Suppress("UNUSED_PARAMETER")
 @Composable
-fun GroupDetailScreen() {
+fun GroupDetailScreen(
+    groupId: Long,
+    onBack: () -> Unit,
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(BookiiBookiiTheme.colors.uiBg),
     ) {
-        GroupDetailHeader()
+        GroupDetailHeader(onBack = onBack)
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -79,7 +84,7 @@ fun GroupDetailScreen() {
 
 // 헤더
 @Composable
-private fun GroupDetailHeader() {
+private fun GroupDetailHeader(onBack: () -> Unit) {
     Column(modifier = Modifier.fillMaxWidth().background(BookiiBookiiTheme.colors.white)) {
         Box(
             modifier = Modifier
@@ -88,7 +93,7 @@ private fun GroupDetailHeader() {
                 .padding(horizontal = 16.dp),
         ) {
             IconButton(
-                onClick = {},
+                onClick = onBack,
                 modifier = Modifier
                     .align(Alignment.CenterStart)
                     .size(40.dp),
@@ -457,6 +462,6 @@ private fun GroupDetailHostChip() {
 @Composable
 private fun GroupDetailScreenPreview() {
     BookiiPreview {
-        GroupDetailScreen()
+        GroupDetailScreen(groupId = 0L, onBack = {})
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/joinrequest/GroupJoinRequestScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/joinrequest/GroupJoinRequestScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
 import com.bookiibookii.bookiibookii.ui.component.BottomSheetTwoBtnShort
+import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
@@ -168,12 +169,8 @@ private fun JoinRequestUserRow(nickname: String, date: String) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .size(48.dp)
-                .clip(CircleShape)
-                .background(BookiiBookiiTheme.colors.uiBg),
-        )
+        // 프로필 이미지 — JoinRequestItem에 profileImageUrl 추가 시 imageUrl 전달 (VM 연결 후속 작업)
+        ProfilePlaceholder(modifier = Modifier.size(48.dp))
         Column {
             Text(
                 text = nickname,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
@@ -1,6 +1,7 @@
 package com.bookiibookii.bookiibookii.group.ui.search
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +33,7 @@ fun ExploreGroupCard(
     expectedDays: Int,
     nickname: String,
     groupName: String,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
     imageUrl: String? = null,
 ) {
@@ -40,6 +42,7 @@ fun ExploreGroupCard(
             .fillMaxWidth()
             .clip(BookiiBookiiTheme.shape.round20)
             .background(BookiiBookiiTheme.colors.white)
+            .clickable(onClick = onClick)
             .padding(16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
@@ -164,6 +167,7 @@ private fun ExploreGroupCardPreview() {
             expectedDays = 7,
             nickname = "닉네임",
             groupName = "그룹명",
+            onClick = {},
         )
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/ExploreGroupCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bookiibookii.bookiibookii.ui.component.BookCover
+import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
@@ -36,6 +37,7 @@ fun ExploreGroupCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     imageUrl: String? = null,
+    hostProfileImageUrl: String? = null,
 ) {
     Row(
         modifier = modifier
@@ -105,12 +107,9 @@ fun ExploreGroupCard(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    // 프로필 이미지 placeholder
-                    Box(
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clip(BookiiBookiiTheme.shape.round50)
-                            .background(BookiiBookiiTheme.colors.uiBg),
+                    ProfilePlaceholder(
+                        modifier = Modifier.size(20.dp),
+                        imageUrl = hostProfileImageUrl,
                     )
                     Text(
                         text = nickname,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
@@ -221,6 +221,7 @@ fun GroupSearchScreen(
                                 groupName = item.groupName,
                                 onClick = { onGroupClick(item.groupId) },
                                 imageUrl = item.bookImage,
+                                hostProfileImageUrl = item.hostProfileImageUrl,
                             )
                         }
                         if (uiState.loadingMore) {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/GroupSearchScreen.kt
@@ -52,6 +52,7 @@ private enum class FilterSheet { EXCHANGE, GENRE }
 @Composable
 fun GroupSearchRoute(
     onBack: () -> Unit,
+    onGroupClick: (Long) -> Unit,
     viewModel: GroupSearchViewModel = viewModel(),
 ) {
     val uiState by viewModel.state.collectAsStateWithLifecycle()
@@ -64,6 +65,7 @@ fun GroupSearchRoute(
         onApplyTradeTypes = viewModel::applyTradeTypes,
         onApplyCategories = viewModel::applyCategories,
         onLoadMore = viewModel::loadMore,
+        onGroupClick = onGroupClick,
     )
 }
 
@@ -79,6 +81,7 @@ fun GroupSearchScreen(
     onApplyTradeTypes: (List<String>) -> Unit,
     onApplyCategories: (List<String>) -> Unit,
     onLoadMore: () -> Unit,
+    onGroupClick: (Long) -> Unit,
 ) {
     var openSheet by remember { mutableStateOf<FilterSheet?>(null) }
     val sheetState = rememberModalBottomSheetState()
@@ -216,6 +219,7 @@ fun GroupSearchScreen(
                                 expectedDays = item.readingPeriod,
                                 nickname = item.hostNickname.orEmpty(),
                                 groupName = item.groupName,
+                                onClick = { onGroupClick(item.groupId) },
                                 imageUrl = item.bookImage,
                             )
                         }
@@ -325,6 +329,7 @@ private fun GroupSearchScreenPreview() {
             onApplyTradeTypes = {},
             onApplyCategories = {},
             onLoadMore = {},
+            onGroupClick = {},
         )
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupCommentViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupCommentViewModel.kt
@@ -1,0 +1,240 @@
+package com.bookiibookii.bookiibookii.group.vm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bookiibookii.bookiibookii.data.api.RetrofitClient
+import com.bookiibookii.bookiibookii.data.model.group.CommentCreateRequest
+import com.bookiibookii.bookiibookii.data.model.group.CommentCreateResponse
+import com.bookiibookii.bookiibookii.data.model.group.CommentItem
+import com.bookiibookii.bookiibookii.group.model.GroupCommentUiState
+import com.bookiibookii.bookiibookii.group.nav.GroupDestinations
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class GroupCommentViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
+
+    // 라우트 인자로 받은 그룹 id. GroupDetail VM과 동일한 키 공유
+    private val groupId: Long = checkNotNull(savedStateHandle[GroupDestinations.ARG_GROUP_ID]) {
+        "groupId is required"
+    }
+
+    private val _state = MutableStateFlow(GroupCommentUiState())
+    val state: StateFlow<GroupCommentUiState> = _state
+
+    private val _eventFlow = MutableSharedFlow<Event>()
+    val eventFlow: SharedFlow<Event> = _eventFlow.asSharedFlow()
+
+    // 일회성 이벤트 — 토스트/스낵바용
+    sealed class Event {
+        data class ShowError(val message: String) : Event()
+    }
+
+    init {
+        load()
+    }
+
+    // -- 데이터 로드 --
+
+    private fun load() {
+        viewModelScope.launch {
+            _state.update { it.copy(loading = true, error = null) }
+            try {
+                val res = RetrofitClient.grpApi().getComments(groupId)
+                val list = res.body()?.result
+                if (res.isSuccessful && res.body()?.isSuccess == true && list != null) {
+                    _state.update {
+                        it.copy(
+                            comments = list,
+                            totalCount = countAll(list),
+                            loading = false,
+                            error = null,
+                        )
+                    }
+                } else {
+                    _state.update { it.copy(error = "댓글을 불러오지 못했어요", loading = false) }
+                }
+            } catch (e: Exception) {
+                _state.update { it.copy(error = "네트워크 오류가 발생했어요", loading = false) }
+            }
+        }
+    }
+
+    fun retry() = load()
+
+    // -- 입력 필드 --
+
+    // 250자 cap
+    // 답글 모드일 땐 mention prefix atomicity 적용
+    // "한 글자라도 지우면 멘션 전체 삭제 + 답글 해제" 요구사항
+    fun onDraftChange(text: String) {
+        val s = _state.value
+        if (s.mentionNickname != null) {
+            val prefix = mentionPrefix(s.mentionNickname)
+            if (!text.startsWith(prefix)) {
+                _state.update {
+                    it.copy(
+                        draft = "",
+                        replyTargetId = null,
+                        mentionNickname = null,
+                        draftSecret = false,
+                    )
+                }
+                return
+            }
+        }
+        val capped = if (text.length > MAX_CONTENT_LEN) text.take(MAX_CONTENT_LEN) else text
+        _state.update { it.copy(draft = capped) }
+    }
+
+    fun toggleSecret() {
+        _state.update { it.copy(draftSecret = !it.draftSecret) }
+    }
+
+    // 답글 모드 진입. replyRequestId를 증가시켜 같은 댓글 재클릭에도 UI가 focus/키보드를 재요청하게 함
+    fun startReply(parentId: Long, nickname: String) {
+        _state.update {
+            it.copy(
+                replyTargetId = parentId,
+                mentionNickname = nickname,
+                draft = mentionPrefix(nickname),
+                replyRequestId = it.replyRequestId + 1,
+            )
+        }
+    }
+
+    // 답글 모드 해제
+    fun cancelReply() {
+        _state.update {
+            it.copy(
+                draft = "",
+                replyTargetId = null,
+                mentionNickname = null,
+                draftSecret = false,
+            )
+        }
+    }
+
+    // -- 댓글 작성 --
+
+    fun submit() {
+        val s = _state.value
+        val content = if (s.mentionNickname != null) {
+            s.draft.removePrefix(mentionPrefix(s.mentionNickname)).trim()
+        } else {
+            s.draft.trim()
+        }
+        if (content.isEmpty() || s.submitting) return
+
+        // secret은 대댓글일 때만 가능. 일반 댓글이면 false 강제
+        val isReply = s.replyTargetId != null
+        val secret = isReply && s.draftSecret
+
+        viewModelScope.launch {
+            _state.update { it.copy(submitting = true) }
+            try {
+                val res = RetrofitClient.grpApi().postComment(
+                    groupId = groupId,
+                    request = CommentCreateRequest(
+                        content = content,
+                        parentId = s.replyTargetId,
+                        secret = secret,
+                    ),
+                )
+                val created = res.body()?.result
+                if (res.isSuccessful && res.body()?.isSuccess == true && created != null) {
+                    val newItem = created.toCommentItem(secret = secret)
+                    _state.update { addLocally(it, newItem) }
+                } else {
+                    _eventFlow.emit(Event.ShowError("댓글 작성에 실패했어요"))
+                    _state.update { it.copy(submitting = false) }
+                }
+            } catch (e: Exception) {
+                _eventFlow.emit(Event.ShowError("네트워크 오류가 발생했어요"))
+                _state.update { it.copy(submitting = false) }
+            }
+        }
+    }
+
+    // 응답 댓글을 트리에 끼워넣고 입력 상태 리셋
+    private fun addLocally(s: GroupCommentUiState, item: CommentItem): GroupCommentUiState {
+        val nextComments = if (item.parentId == null) {
+            // 일반 댓글 — 시간순 정렬이라 맨 뒤에 append
+            s.comments + item
+        } else {
+            // 대댓글 — 부모 찾아서 children 끝에 append
+            s.comments.map { parent ->
+                if (parent.id == item.parentId) {
+                    parent.copy(children = (parent.children ?: emptyList()) + item)
+                } else {
+                    parent
+                }
+            }
+        }
+        return s.copy(
+            comments = nextComments,
+            totalCount = countAll(nextComments),
+            // 입력 상태 리셋
+            draft = "",
+            draftSecret = false,
+            replyTargetId = null,
+            mentionNickname = null,
+            submitting = false,
+        )
+    }
+
+    // -- 댓글 삭제 (DELETE 성공 시 reload) --
+
+    fun delete(commentId: Long) {
+        val s = _state.value
+        if (commentId in s.deletingIds) return
+
+        viewModelScope.launch {
+            _state.update { it.copy(deletingIds = it.deletingIds + commentId) }
+            try {
+                val res = RetrofitClient.grpApi().deleteComment(
+                    groupId = groupId,
+                    commentId = commentId,
+                )
+                if (res.isSuccessful && res.body()?.isSuccess == true) {
+                    // 성공 후 재조회
+                    load()
+                } else {
+                    _eventFlow.emit(Event.ShowError("댓글 삭제에 실패했어요"))
+                }
+            } catch (e: Exception) {
+                _eventFlow.emit(Event.ShowError("네트워크 오류가 발생했어요"))
+            } finally {
+                _state.update { it.copy(deletingIds = it.deletingIds - commentId) }
+            }
+        }
+    }
+
+    companion object {
+        private const val MAX_CONTENT_LEN = 250
+    }
+}
+
+// "@{닉네임} " (뒤에 공백 1) — 입력 필드 멘션 prefix
+private fun mentionPrefix(nickname: String): String = "@$nickname "
+
+// 부모 + 답글 합산
+private fun countAll(comments: List<CommentItem>): Int =
+    comments.sumOf { 1 + (it.children?.size ?: 0) }
+
+// POST 응답을 화면용 CommentItem으로 변환
+private fun CommentCreateResponse.toCommentItem(secret: Boolean): CommentItem = CommentItem(
+    id = commentId,
+    deleted = false,
+    secret = secret,
+    content = content,
+    parentId = parentId,
+    writer = writer,
+    createdAt = createdAt,
+    children = null,
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupDetailViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupDetailViewModel.kt
@@ -1,0 +1,58 @@
+package com.bookiibookii.bookiibookii.group.vm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.bookiibookii.bookiibookii.data.api.RetrofitClient
+import com.bookiibookii.bookiibookii.group.model.GroupDetailUiState
+import com.bookiibookii.bookiibookii.group.model.groupDetailActionButton
+import com.bookiibookii.bookiibookii.group.nav.GroupDestinations
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class GroupDetailViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
+
+    // 라우트로 전달된 그룹 id (NavType.LongType이라 Long으로 꺼냄)
+    private val groupId: Long = checkNotNull(savedStateHandle[GroupDestinations.ARG_GROUP_ID]) {
+        "groupId is required"
+    }
+
+    private val _state = MutableStateFlow(GroupDetailUiState())
+    val state: StateFlow<GroupDetailUiState> = _state
+
+    init {
+        // 진입 시 즉시 상세 조회
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _state.update { it.copy(loading = true, error = null) }
+            try {
+                val res = RetrofitClient.grpApi().getGroupDetail(groupId)
+                val detail = res.body()?.result
+                if (res.isSuccessful && res.body()?.isSuccess == true && detail != null) {
+                    _state.update {
+                        it.copy(
+                            detail = detail,
+                            actionButton = groupDetailActionButton(
+                                buttonStatus = detail.buttonStatus,
+                                waitingCount = detail.waitingCount,
+                            ),
+                            loading = false,
+                            error = null,
+                        )
+                    }
+                } else {
+                    _state.update { it.copy(error = "그룹 정보를 불러오지 못했어요", loading = false) }
+                }
+            } catch (e: Exception) {
+                _state.update { it.copy(error = "네트워크 오류가 발생했어요", loading = false) }
+            }
+        }
+    }
+
+    fun retry() = load()
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
@@ -70,6 +70,14 @@ object TokenManager {
         return prefs(context).getString(KEY_REFRESH, null)
     }
 
+    // 로그인된 사용자 id. 저장 안 됐으면 null.
+    // Int로 저장돼 있지만 서버 모델은 대부분 Long이라 Long으로 노출.
+    // (임시) 댓글 본인 여부 비교용. 백엔드가 isMe 필드 추가하면 제거 예정
+    fun getUserId(context: Context): Long? {
+        val id = prefs(context).getInt(KEY_USER_ID, -1)
+        return if (id == -1) null else id.toLong()
+    }
+
     /**
      * JWT payload의 exp 값을 디코딩하여 만료 여부를 판단합니다.
      * 파싱 실패 시 안전하게 "만료"로 처리합니다.

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
@@ -71,7 +71,6 @@ object TokenManager {
     }
 
     // 로그인된 사용자 id. 저장 안 됐으면 null.
-    // Int로 저장돼 있지만 서버 모델은 대부분 Long이라 Long으로 노출.
     // (임시) 댓글 본인 여부 비교용. 백엔드가 isMe 필드 추가하면 제거 예정
     fun getUserId(context: Context): Long? {
         val id = prefs(context).getInt(KEY_USER_ID, -1)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerDetailContent.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerDetailContent.kt
@@ -1,7 +1,6 @@
 package com.bookiibookii.bookiibookii.tracker.ui.detail.component
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -28,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -38,6 +36,7 @@ import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.tracker.model.TrackerProfileItem
 import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
 import com.bookiibookii.bookiibookii.ui.component.BottomSheetTwoBtnShort
+import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
@@ -357,18 +356,13 @@ private fun ProfileColumn(
                 }
             }
         }
-        Box(
+        ProfilePlaceholder(
             modifier = Modifier
                 .offset(x = 27.dp, y = 0.dp)
                 .size(44.dp),
-        ) {
-            Image(
-                painter = painterResource(R.drawable.profile_bg),
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-                colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey500),
-            )
-        }
+            imageUrl = profile.profileImageUrl,
+            innerStroke = true,
+        )
     }
 }
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerReadingPeriodEditDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/component/TrackerReadingPeriodEditDialog.kt
@@ -121,7 +121,7 @@ private fun TrackerReadingPeriodEditDialogContent(
             }
             Text(
                 text = "${displayMonth.year}년 ${displayMonth.monthValue}월",
-                style = BookiiBookiiTheme.typography.semibold20,
+                style = BookiiBookiiTheme.typography.medium20,
                 color = BookiiBookiiTheme.colors.grey900,
             )
             Box(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/main/TrackerMainCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/main/TrackerMainCard.kt
@@ -1,12 +1,10 @@
 package com.bookiibookii.bookiibookii.tracker.ui.main
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -19,16 +17,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.tracker.model.TrackerCardModel
 import com.bookiibookii.bookiibookii.tracker.model.TrackerProfileItem
 import com.bookiibookii.bookiibookii.ui.component.BottomSheetBtnStyle
 import com.bookiibookii.bookiibookii.ui.component.BottomSheetTwoBtnShort
+import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
@@ -198,18 +194,13 @@ private fun TrackerProfileColumn(
                 }
             }
         }
-        Box(
+        ProfilePlaceholder(
             modifier = Modifier
                 .offset(x = 17.dp, y = 0.dp)
                 .size(44.dp),
-        ) {
-            Image(
-                painter = painterResource(R.drawable.profile_bg),
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-                colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey500),
-            )
-        }
+            imageUrl = profile.profileImageUrl,
+            innerStroke = true,
+        )
     }
 }
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/review/TrackerPartnerReviewScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/review/TrackerPartnerReviewScreen.kt
@@ -289,7 +289,7 @@ private fun BookColumn(
                     }
                 }
             }
-            // TrackerCard 위 파트너 오버레이 — BookCover와 겹치므로 innerStroke=true. URL은 VM 연결 후속
+            // TrackerCard 위 파트너 오버레이 — BookCover와 겹치므로 innerStroke=true
             ProfilePlaceholder(
                 modifier = Modifier
                     .align(Alignment.TopStart)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/review/TrackerPartnerReviewScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/review/TrackerPartnerReviewScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.ui.component.FooterButton
+import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
@@ -135,12 +136,8 @@ private fun ReviewCard(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Box(
-                modifier = Modifier
-                    .size(20.dp)
-                    .clip(CircleShape)
-                    .background(BookiiBookiiTheme.colors.grey200),
-            )
+            // 파트너 프로필 — VM 연결 시 imageUrl 와이어링
+            ProfilePlaceholder(modifier = Modifier.size(20.dp))
             Text(
                 text = buildAnnotatedString {
                     withStyle(SpanStyle(color = BookiiBookiiTheme.colors.uiMain)) {
@@ -292,13 +289,13 @@ private fun BookColumn(
                     }
                 }
             }
-            Box(
+            // TrackerCard 위 파트너 오버레이 — BookCover와 겹치므로 innerStroke=true. URL은 VM 연결 후속
+            ProfilePlaceholder(
                 modifier = Modifier
                     .align(Alignment.TopStart)
                     .padding(start = 17.dp)
-                    .size(44.dp)
-                    .clip(CircleShape)
-                    .background(BookiiBookiiTheme.colors.grey200),
+                    .size(44.dp),
+                innerStroke = true,
             )
         }
         Text(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/DeletePopover.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/DeletePopover.kt
@@ -1,0 +1,77 @@
+package com.bookiibookii.bookiibookii.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// "삭제" 한 줄짜리 dropdown
+// - 사용처: 댓글 long-press 시 본인 댓글 아래에 나타남
+// - 클릭 영역 전체에서 onDeleteClick 호출
+@Composable
+fun DeletePopover(
+    onDeleteClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(10.dp)
+    Column(
+        modifier = modifier
+            .shadow(elevation = 4.dp, shape = shape)
+            .clip(shape)
+            .background(BookiiBookiiTheme.colors.white)
+            .border(width = 1.dp, color = BookiiBookiiTheme.colors.grey200, shape = shape)
+            .padding(vertical = 4.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onDeleteClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "삭제",
+                style = BookiiBookiiTheme.typography.medium14,
+                color = BookiiBookiiTheme.colors.grey700,
+            )
+            Icon(
+                painter = painterResource(R.drawable.ic_trash),
+                contentDescription = "삭제",
+                tint = BookiiBookiiTheme.colors.grey700,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DeletePopoverPreview() {
+    BookiiPreview {
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            DeletePopover(onDeleteClick = {})
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/ProfilePlaceholder.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/ProfilePlaceholder.kt
@@ -1,0 +1,108 @@
+package com.bookiibookii.bookiibookii.ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.GenericShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// profile_bg.xml의 squircle path (viewport 44×44 기준) → Compose Shape으로 변환
+// 호출처가 modifier.size()로 정한 크기에 맞춰 자동 scale
+private val ProfileSquircleShape: Shape = GenericShape { size, _ ->
+    val sx = size.width / 44f
+    val sy = size.height / 44f
+    moveTo(0f, 22f * sy)
+    cubicTo(0f, 3.883f * sy, 3.883f * sx, 0f, 22f * sx, 0f)
+    cubicTo(40.117f * sx, 0f, size.width, 3.883f * sy, size.width, 22f * sy)
+    cubicTo(size.width, 40.117f * sy, 40.117f * sx, size.height, 22f * sx, size.height)
+    cubicTo(3.883f * sx, size.height, 0f, 40.117f * sy, 0f, 22f * sy)
+    close()
+}
+
+// 프로필 영역 (placeholder + 실제 이미지)
+// - 크기는 호출처에서 modifier.size()
+// - imageUrl == null/blank → profile_bg 모양에 grey500 채움 (기본 placeholder)
+// - imageUrl != null → 위에 AsyncImage 오버레이 (squircle로 잘림)
+// - innerStroke == true → 안쪽 1dp grey100 stroke. BookCover와 겹치는 자리에만 true
+@Composable
+fun ProfilePlaceholder(
+    modifier: Modifier = Modifier,
+    imageUrl: String? = null,
+    innerStroke: Boolean = false,
+) {
+    Box(modifier = modifier.clip(ProfileSquircleShape)) {
+        // 배경 placeholder — 항상 깔아둠. AsyncImage 로딩 전/실패 시 노출
+        Image(
+            painter = painterResource(R.drawable.profile_bg),
+            contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey500),
+        )
+        if (!imageUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+        // 안쪽 stroke는 마지막에 그려야 AsyncImage 위에 보임
+        if (innerStroke) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .border(
+                        width = 1.dp,
+                        color = BookiiBookiiTheme.colors.grey100,
+                        shape = ProfileSquircleShape,
+                    ),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProfilePlaceholderPreview() {
+    BookiiPreview {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            ProfilePlaceholder(modifier = Modifier.size(20.dp))
+            ProfilePlaceholder(modifier = Modifier.size(40.dp))
+            ProfilePlaceholder(modifier = Modifier.size(44.dp))
+            ProfilePlaceholder(modifier = Modifier.size(48.dp))
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProfilePlaceholderWithStrokePreview() {
+    BookiiPreview {
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            ProfilePlaceholder(
+                modifier = Modifier.size(44.dp),
+                innerStroke = true,
+            )
+            ProfilePlaceholder(
+                modifier = Modifier.size(44.dp),
+                innerStroke = false,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/ProfilePlaceholder.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/ProfilePlaceholder.kt
@@ -38,8 +38,8 @@ private val ProfileSquircleShape: Shape = GenericShape { size, _ ->
 // 프로필 영역 (placeholder + 실제 이미지)
 // - 크기는 호출처에서 modifier.size()
 // - imageUrl == null/blank → profile_bg 모양에 grey500 채움 (기본 placeholder)
-// - imageUrl != null → 위에 AsyncImage 오버레이 (squircle로 잘림)
-// - innerStroke == true → 안쪽 1dp grey100 stroke. BookCover와 겹치는 자리에만 true
+// - imageUrl != null → 위에 AsyncImage 오버레이
+// - innerStroke == true → 안쪽 1dp grey100 stroke. BookCover와 겹칠 때만 true 넣기
 @Composable
 fun ProfilePlaceholder(
     modifier: Modifier = Modifier,
@@ -62,7 +62,7 @@ fun ProfilePlaceholder(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        // 안쪽 stroke는 마지막에 그려야 AsyncImage 위에 보임
+        // 안쪽 stroke
         if (innerStroke) {
             Box(
                 modifier = Modifier


### PR DESCRIPTION
# 📌 Pull Request Title
> - feat: 댓글 ui 완성 및 그룹 상세 api 연결 (#312)

---

# ✨ 작업 내용 (What)
> - 그룹 상세 진입점 연결
> - 그룹 상세 API/VM 연결 
> - DateUtils 단순화, DeletePopover 공용 컴포넌트 추가
> - 댓글 자체 QA 진행
> - 이미지 공용 placeholder 추가. 배경으로 깔고 사용하면 됨

---

# 💡추가 사항
> - 댓글 삭제 ui 컨펌 받기
> - 비밀 댓글 ui도

---

# 🔗 관련 이슈 (Optional)
- close #312
