### PR TITLE
fix: 앱 재설치 시 토큰 복호화 실패로 인한 실행 크래시 수정 (#357)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/login/Tokenmanager.kt
@@ -26,20 +26,32 @@ object TokenManager {
         return synchronized(this) {
             encryptedPrefs ?: run {
                 val appContext = context.applicationContext
-                val masterKey = MasterKey.Builder(appContext)
-                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-                    .build()
-                val created = EncryptedSharedPreferences.create(
-                    appContext,
-                    PREF,
-                    masterKey,
-                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-                )
+                val created = try {
+                    buildEncryptedPrefs(appContext)
+                } catch (e: Exception) {
+                    // 백업 복원 등으로 마스터키-keyset 불일치(AEADBadTagException) → 복호화 불가
+                    // 깨진 prefs 파일을 삭제하고 재생성하여 자가복구
+                    // (복원된 토큰은 어차피 못 쓰는 값이라 버리고 로그인 화면으로 정상 진입)
+                    appContext.deleteSharedPreferences(PREF)
+                    buildEncryptedPrefs(appContext)
+                }
                 encryptedPrefs = created
                 created
             }
         }
+    }
+
+    private fun buildEncryptedPrefs(appContext: Context): SharedPreferences {
+        val masterKey = MasterKey.Builder(appContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        return EncryptedSharedPreferences.create(
+            appContext,
+            PREF,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
 
     fun saveTokens(context: Context, access: String, refresh: String, userId: Long) {

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample backup rules file; uncomment and customize as necessary.
-   See https://developer.android.com/guide/topics/data/autobackup
-   for details.
-   Note: This file is ignored for devices older than API 31
-   See https://developer.android.com/about/versions/12/backup-restore
+   Auto Backup 규칙 (API < 31).
+   암호화 토큰 prefs(auth_prefs_enc)는 백업/복원 대상에서 제외.
+   마스터키(AndroidKeyStore)는 복원되지 않으므로, 파일만 복원되면
+   복호화 실패(AEADBadTagException)로 앱이 크래시하기 때문.
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <exclude domain="sharedpref" path="auth_prefs_enc.xml" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
+   데이터 추출 규칙 (API 31+).
+   암호화 토큰 prefs(auth_prefs_enc)는 클라우드 백업/기기 이전 대상에서 제외한다.
+   마스터키(AndroidKeyStore)는 복원되지 않으므로, 파일만 복원되면
+   복호화 실패(AEADBadTagException)로 앱이 크래시하기 때문.
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="sharedpref" path="auth_prefs_enc.xml" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="sharedpref" path="auth_prefs_enc.xml" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
# 📌 Pull Request Title
> - fix: 앱 재설치 시 토큰 복호화 실패로 인한 실행 크래시 수정

---

# ✨ 작업 내용 (What)
> - 앱 재설치 시 백업 규칙으로 auth_prefs_enc가 복원됨. 이 파일 복호화하는 마스터키는 백업 대상에서 제외. 그래서 앱 크래시
> - auth_prefs_enc 백업 대상에서 제외
> - 복호화 실패 시 auth_prefs_enc 재생성

---

# 🔗 관련 이슈 (Optional)
- close #357
