### PR TITLE
feat: 독서카드 공유 기능 1차 구현 (#364)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,24 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".library.feat.PublicCardViewerActivity"
+            android:exported="true"
+            android:theme="@style/Theme.BookiiBookii">
+            <!-- 독서카드 공유 링크 진입 (App Links). host는 실제 shareUrl 도메인에 맞게 수정 필요 -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="bookiibookii.com"
+                    android:pathPrefix="/share/reading-card" />
+            </intent-filter>
+        </activity>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <!-- 독서카드 갤러리 저장 — Android 9(API 28) 이하에서만 필요 (Q+는 MediaStore로 권한 불필요) -->
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <application
         android:name=".onboarding.login.MyApplication"

--- a/app/src/main/java/com/bookiibookii/bookiibookii/MainActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/MainActivity.kt
@@ -18,6 +18,8 @@ import com.bookiibookii.bookiibookii.databinding.ActivityMainBinding
 import com.bookiibookii.bookiibookii.group.GroupFragment
 import com.bookiibookii.bookiibookii.home.HomeFragment
 import com.bookiibookii.bookiibookii.library.feat.LibraryFragment
+import com.bookiibookii.bookiibookii.library.feat.PendingShareToken
+import com.bookiibookii.bookiibookii.library.feat.PublicCardViewerActivity
 import com.bookiibookii.bookiibookii.onboarding.login.LoginActivity
 import com.bookiibookii.bookiibookii.onboarding.login.TokenManager
 import com.bookiibookii.bookiibookii.tracker.TrackerFragment
@@ -61,6 +63,17 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         initBottomNav()
         observeFragmentChanges()
         handleNavigationIntent(intent)
+
+        // 공유 링크로 진입했다가 로그인한 경우 — 저장된 shareToken으로 카드 뷰어 복귀
+        if (savedInstanceState == null) {
+            PendingShareToken.consume(this)?.let { token ->
+                startActivity(
+                    Intent(this, PublicCardViewerActivity::class.java).apply {
+                        putExtra(PublicCardViewerActivity.EXTRA_SHARE_TOKEN, token)
+                    },
+                )
+            }
+        }
     }
 
     // 탑레벨 Fragment(홈·트래커·서재 메인)일 때만 BottomNav 표시

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/LibApi.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/LibApi.kt
@@ -14,6 +14,8 @@ import com.bookiibookii.bookiibookii.data.model.library.MemberCardResponseDTO
 import com.bookiibookii.bookiibookii.data.model.library.MemberCardUpdateRequestDTO
 import com.bookiibookii.bookiibookii.data.model.library.MemberReviewCreateDTO
 import com.bookiibookii.bookiibookii.data.model.library.PresignedUrlResponseDTO
+import com.bookiibookii.bookiibookii.data.model.library.PublicReadingCardResponseDTO
+import com.bookiibookii.bookiibookii.data.model.library.ShareTokenResponseDTO
 import com.bookiibookii.bookiibookii.data.model.library.TrackerResponse
 import retrofit2.Response
 import retrofit2.http.Body
@@ -88,6 +90,17 @@ interface LibApi {
     suspend fun deleteCard(
         @Path("cardId") cardId: Long
     ): Response<ApiResponse<String>>
+
+    @POST("api/member-books/cards/{cardId}/share-token")
+    suspend fun createShareToken(
+        @Path("cardId") cardId: Long
+    ): Response<ApiResponse<ShareTokenResponseDTO>>
+
+    // 공유 토큰 기반 공개 조회 — 인증 불필요, ApiResponse 래퍼 없이 DTO 직접 반환
+    @GET("api/public/reading-cards/{shareToken}")
+    suspend fun getPublicReadingCard(
+        @Path("shareToken") shareToken: String
+    ): Response<PublicReadingCardResponseDTO>
 
     // ── Reviews ────────────────────────────────────────────────────────────────
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/api/S3Uploader.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/api/S3Uploader.kt
@@ -31,28 +31,40 @@ object S3Uploader {
         presignedPutUrl: String
     ): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {
-            val bytes = compressImage(contentResolver, uri)
+            putBytes(compressImage(decodeImage(contentResolver, uri)), presignedPutUrl)
+        }
+    }
 
-            // TODO: 추후 로그 삭제
-            android.util.Log.d("IMG_UPLOAD", "upload size=${bytes.size}B (${bytes.size / 1024}KB)")
+    // File 기반 오버로드 — File을 다루는 흐름(마이페이지 프로필 수정 등)도 동일 압축/업로드 적용
+    suspend fun uploadImage(
+        file: File,
+        presignedPutUrl: String
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            putBytes(compressImage(decodeImage(file)), presignedPutUrl)
+        }
+    }
 
-            val requestBody = bytes.toRequestBody(MIME_JPEG.toMediaTypeOrNull())
-            val request = Request.Builder()
-                .url(presignedPutUrl)
-                .put(requestBody)
-                .addHeader("Content-Type", MIME_JPEG)
-                .build()
+    // 압축된 JPEG 바이트를 presigned URL로 PUT
+    private fun putBytes(bytes: ByteArray, presignedPutUrl: String) {
+        // TODO: 추후 로그 삭제
+        android.util.Log.d("IMG_UPLOAD", "upload size=${bytes.size}B (${bytes.size / 1024}KB)")
 
-            client.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    error("S3 업로드 실패: HTTP ${response.code}")
-                }
+        val requestBody = bytes.toRequestBody(MIME_JPEG.toMediaTypeOrNull())
+        val request = Request.Builder()
+            .url(presignedPutUrl)
+            .put(requestBody)
+            .addHeader("Content-Type", MIME_JPEG)
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                error("S3 업로드 실패: HTTP ${response.code}")
             }
         }
     }
 
-    private fun compressImage(contentResolver: ContentResolver, uri: Uri): ByteArray {
-        val bitmap = decodeImage(contentResolver, uri)
+    private fun compressImage(bitmap: Bitmap): ByteArray {
         try {
             var quality = INITIAL_QUALITY
             var bytes = bitmap.toJpegBytes(quality)
@@ -74,8 +86,13 @@ object S3Uploader {
         } else {
             ImageDecoder.createSource(contentResolver, uri)
         }
+        return decodeBitmap(source)
+    }
 
-        return ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+    private fun decodeImage(file: File): Bitmap = decodeBitmap(ImageDecoder.createSource(file))
+
+    private fun decodeBitmap(source: ImageDecoder.Source): Bitmap =
+        ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
             val longSide = maxOf(info.size.width, info.size.height)
             if (longSide > MAX_LONG_SIDE_PX) {
                 val ratio = MAX_LONG_SIDE_PX.toFloat() / longSide
@@ -87,7 +104,6 @@ object S3Uploader {
             // ALLOCATOR_SOFTWARE: hardware bitmap은 Bitmap.compress() 불가
             decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
         }
-    }
 
     private fun Bitmap.toJpegBytes(quality: Int): ByteArray {
         val output = ByteArrayOutputStream()

--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/library/Cards.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/library/Cards.kt
@@ -88,3 +88,23 @@ data class PresignedUrlResponseDTO(
     val s3Key: String,
     val presignedPutUrl: String
 )
+
+// 독서카드 공유 토큰 발급 응답 (POST /api/member-books/cards/{cardId}/share-token)
+data class ShareTokenResponseDTO(
+    val shareToken: String,
+    val shareUrl: String
+)
+
+// 공유 토큰 기반 독서카드 공개 조회 응답 (GET /api/public/reading-cards/{shareToken})
+// 공개 엔드포인트라 ApiResponse 래퍼 없이 DTO를 직접 반환한다. required 없음 → 전부 nullable.
+data class PublicReadingCardResponseDTO(
+    val cardType: String?,
+    val bookTitle: String?,
+    val bookAuthor: String?,
+    val bookImage: String?,
+    val creatorNickname: String?,
+    val page: Int?,
+    val memo: String?,
+    val quotation: String?,
+    val imageUrl: String?,
+)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/PendingShareToken.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/PendingShareToken.kt
@@ -1,0 +1,26 @@
+package com.bookiibookii.bookiibookii.library.feat
+
+import android.content.Context
+
+// 비로그인 공유 링크 진입 시 shareToken을 임시 저장.
+// 로그인 체인이 CLEAR_TASK라 백스택 복귀가 불가 → 로그인 완료 후 MainActivity에서 consume해 뷰어로 복귀.
+object PendingShareToken {
+
+    private const val PREF = "share_pending"
+    private const val KEY = "share_token"
+
+    fun save(context: Context, token: String) {
+        context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY, token)
+            .apply()
+    }
+
+    // 저장된 토큰을 반환하고 즉시 비운다(1회성).
+    fun consume(context: Context): String? {
+        val prefs = context.getSharedPreferences(PREF, Context.MODE_PRIVATE)
+        val token = prefs.getString(KEY, null)
+        if (token != null) prefs.edit().remove(KEY).apply()
+        return token
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/PublicCardViewerActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/PublicCardViewerActivity.kt
@@ -1,0 +1,145 @@
+package com.bookiibookii.bookiibookii.library.feat
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.data.api.RetrofitClient
+import com.bookiibookii.bookiibookii.library.ui.PublicCardViewerScreen
+import com.bookiibookii.bookiibookii.library.ui.ReadingCard
+import com.bookiibookii.bookiibookii.library.vm.toReadingCard
+import com.bookiibookii.bookiibookii.onboarding.Intro.LoginIntroActivity
+import com.bookiibookii.bookiibookii.onboarding.login.TokenManager
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+// 공유 링크(App Links) 진입점.
+// https://<공유도메인>/share/reading-card/{shareToken} → shareToken으로 공개 조회 후 뷰어 표시.
+class PublicCardViewerActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // 링크의 마지막 경로 세그먼트가 shareToken. (내부 호출/테스트용 extra도 허용)
+        val shareToken = intent?.data?.lastPathSegment
+            ?: intent?.getStringExtra(EXTRA_SHARE_TOKEN)
+
+        // 로그인 필수 — 비로그인 시 토큰을 저장해두고 로그인 진입.
+        // 로그인 완료 후 MainActivity가 consume해서 이 화면으로 복귀시킨다.
+        if (!TokenManager.hasAccessToken(this)) {
+            if (!shareToken.isNullOrBlank()) PendingShareToken.save(this, shareToken)
+            startActivity(
+                Intent(this, LoginIntroActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                },
+            )
+            finish()
+            return
+        }
+
+        setContent {
+            BookiiBookiiTheme {
+                var state by remember { mutableStateOf<ViewerState>(ViewerState.Loading) }
+
+                LaunchedEffect(shareToken) {
+                    state = loadCard(shareToken)
+                }
+
+                when (val s = state) {
+                    ViewerState.Loading -> CenterBox { CircularProgressIndicator(color = BookiiBookiiTheme.colors.uiMain) }
+                    ViewerState.Error -> CenterBox {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                text = "독서카드를 불러올 수 없어요",
+                                style = BookiiBookiiTheme.typography.medium16,
+                                color = BookiiBookiiTheme.colors.grey900,
+                                textAlign = TextAlign.Center,
+                            )
+                            Text(
+                                text = "링크가 만료되었거나 삭제된 카드일 수 있어요",
+                                style = BookiiBookiiTheme.typography.regular14,
+                                color = BookiiBookiiTheme.colors.grey500,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
+                    is ViewerState.Success -> PublicCardViewerScreen(
+                        card = s.card,
+                        bookAuthor = s.author,
+                        onClose = { finish() },
+                        onOpenApp = { openApp() },
+                    )
+                }
+            }
+        }
+    }
+
+    // 공개 조회 — libApi(authed)지만 공개 엔드포인트라 토큰 유무와 무관하게 동작
+    private suspend fun loadCard(shareToken: String?): ViewerState {
+        if (shareToken.isNullOrBlank()) return ViewerState.Error
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = RetrofitClient.libApi().getPublicReadingCard(shareToken)
+                val dto = response.body()
+                if (response.isSuccessful && dto != null) {
+                    ViewerState.Success(dto.toReadingCard(), dto.bookAuthor.orEmpty())
+                } else {
+                    ViewerState.Error
+                }
+            } catch (_: Exception) {
+                ViewerState.Error
+            }
+        }
+    }
+
+    // "앱에서 보기" — 런처(LoginIntroActivity)로 진입해 정상 라우팅에 맡김
+    private fun openApp() {
+        startActivity(
+            Intent(this, LoginIntroActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            },
+        )
+        finish()
+    }
+
+    private sealed interface ViewerState {
+        data object Loading : ViewerState
+        data object Error : ViewerState
+        data class Success(val card: ReadingCard, val author: String) : ViewerState
+    }
+
+    companion object {
+        const val EXTRA_SHARE_TOKEN = "extra_share_token"
+    }
+}
+
+@Composable
+private fun CenterBox(content: @Composable () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) { content() }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/ReadingCardDetailFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/ReadingCardDetailFragment.kt
@@ -1,21 +1,29 @@
 package com.bookiibookii.bookiibookii.library.feat
 
+import android.Manifest
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.LinearGradient
 import android.graphics.Paint
 import android.graphics.Shader
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.lifecycle.lifecycleScope
 import com.bookiibookii.bookiibookii.common.showCustomToast
@@ -41,6 +49,19 @@ import java.io.File
 import java.io.FileOutputStream
 
 class ReadingCardDetailFragment : BaseLibraryFragment() {
+
+    // 다운로드 권한(API 28 이하) 승인 후 저장할 카드 보관
+    private var pendingDownloadCard: ReadingCard? = null
+    private val storagePermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            val card = pendingDownloadCard
+            pendingDownloadCard = null
+            if (granted && card != null) {
+                saveCardToGallery(card)
+            } else {
+                requireContext().showCustomToast("저장 권한이 필요해요", false)
+            }
+        }
 
     private val initialIndex get() = arguments?.getInt(ARG_INDEX, 0) ?: 0
     private val sortByLatest get() = arguments?.getBoolean(ARG_SORT, true) ?: true
@@ -86,6 +107,7 @@ class ReadingCardDetailFragment : BaseLibraryFragment() {
                     onCopyLink   = { card -> copyShareLink(card) },
                     onKakaoShare = { card -> shareToKakao(card) },
                     onXShare     = { card -> shareToX(card) },
+                    onDownload   = { card -> downloadCard(card) },
                 )
             }
         }
@@ -182,16 +204,16 @@ class ReadingCardDetailFragment : BaseLibraryFragment() {
         }
     }
 
-    // ── 인스타그램 스토리 공유 ───────────────────────────────────────────────
+    // ── 카드 → 비트맵 캡처 (인스타 공유 / 다운로드 공통) ──────────────────────
+    // 오프스크린 ComposeView로 ShareableCard를 렌더해 비트맵 생성. 결과는 Main 콜백(실패 시 null)
 
-    private fun shareCardToInstagram(card: ReadingCard) {
+    private fun captureShareableCard(card: ReadingCard, onBitmap: (Bitmap?) -> Unit) {
         val context = requireContext()
 
         // 카드 크기: 화면 너비의 80%, 비율 348:464
         val cardWidthPx  = (resources.displayMetrics.widthPixels * 0.8f).toInt()
         val cardHeightPx = (cardWidthPx * 464f / 348f).toInt()
 
-        // 오프스크린 ComposeView로 카드 렌더링
         val cardView = ComposeView(context).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             visibility = View.INVISIBLE
@@ -202,69 +224,148 @@ class ReadingCardDetailFragment : BaseLibraryFragment() {
             }
         }
 
-        val container = (requireView().parent as? ViewGroup) ?: return
+        val container = (requireView().parent as? ViewGroup) ?: run {
+            onBitmap(null)
+            return
+        }
         container.addView(cardView, ViewGroup.LayoutParams(cardWidthPx, cardHeightPx))
 
+        // 레이아웃/컴포지션 완료 대기 후 캡처
         cardView.postDelayed({
-            if (!isAdded) {
-                if (cardView.isAttachedToWindow) container.removeView(cardView)
-                return@postDelayed
-            }
-            try {
+            val bitmap = try {
                 val w = cardView.width
                 val h = cardView.height
-                if (w <= 0 || h <= 0) {
-                    container.removeView(cardView)
-                    return@postDelayed
-                }
-
-                val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
-                val canvas = Canvas(bitmap)
-                cardView.draw(canvas)
-                container.removeView(cardView)
-
-                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                    try {
-                        val imagesDir = File(context.cacheDir, "images").apply { mkdirs() }
-                        imagesDir.listFiles()?.forEach { it.delete() }
-
-                        // 카드 스티커 저장
-                        val stickerFile = File(imagesDir, "card_sticker_${System.currentTimeMillis()}.png")
-                        FileOutputStream(stickerFile).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
-                        bitmap.recycle()
-
-                        val stickerUri = FileProvider.getUriForFile(
-                            context,
-                            "${context.packageName}.fileprovider",
-                            stickerFile,
-                        )
-
-                        // 배경 이미지 (주황 그라데이션 1080×1920)
-                        val bgBitmap = createGradientBackground()
-                        val bgFile = File(imagesDir, "bg_${System.currentTimeMillis()}.png")
-                        FileOutputStream(bgFile).use { bgBitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
-                        bgBitmap.recycle()
-
-                        val backgroundUri = FileProvider.getUriForFile(
-                            context,
-                            "${context.packageName}.fileprovider",
-                            bgFile,
-                        )
-
-                        withContext(Dispatchers.Main) {
-                            launchInstagramStoryIntent(stickerUri, backgroundUri)
-                        }
-                    } catch (e: Exception) {
-                        withContext(Dispatchers.Main) {
-                            if (isAdded) context.showCustomToast("공유 준비 중 오류가 발생했습니다.", false)
-                        }
+                if (!isAdded || w <= 0 || h <= 0) {
+                    null
+                } else {
+                    Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888).also { bmp ->
+                        cardView.draw(Canvas(bmp))
                     }
                 }
-            } catch (e: Exception) {
+            } catch (_: Exception) {
+                null
+            } finally {
                 if (cardView.isAttachedToWindow) container.removeView(cardView)
-                if (isAdded) context.showCustomToast("공유 준비 중 오류가 발생했습니다.", false)
             }
+            onBitmap(bitmap)
         }, 500L)
+    }
+
+    // ── 인스타그램 스토리 공유 ───────────────────────────────────────────────
+
+    private fun shareCardToInstagram(card: ReadingCard) {
+        val context = requireContext()
+        captureShareableCard(card) { bitmap ->
+            if (bitmap == null) {
+                context.showCustomToast("공유 준비 중 오류가 발생했습니다.", false)
+                return@captureShareableCard
+            }
+            viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                try {
+                    val imagesDir = File(context.cacheDir, "images").apply { mkdirs() }
+                    imagesDir.listFiles()?.forEach { it.delete() }
+
+                    // 카드 스티커 저장
+                    val stickerFile = File(imagesDir, "card_sticker_${System.currentTimeMillis()}.png")
+                    FileOutputStream(stickerFile).use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+                    bitmap.recycle()
+
+                    val stickerUri = FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        stickerFile,
+                    )
+
+                    // 배경 이미지 (주황 그라데이션 1080×1920)
+                    val bgBitmap = createGradientBackground()
+                    val bgFile = File(imagesDir, "bg_${System.currentTimeMillis()}.png")
+                    FileOutputStream(bgFile).use { bgBitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+                    bgBitmap.recycle()
+
+                    val backgroundUri = FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        bgFile,
+                    )
+
+                    withContext(Dispatchers.Main) {
+                        launchInstagramStoryIntent(stickerUri, backgroundUri)
+                    }
+                } catch (e: Exception) {
+                    withContext(Dispatchers.Main) {
+                        if (isAdded) context.showCustomToast("공유 준비 중 오류가 발생했습니다.", false)
+                    }
+                }
+            }
+        }
+    }
+
+    // ── 다운로드 (갤러리 저장) ────────────────────────────────────────────────
+    // API 28 이하는 WRITE_EXTERNAL_STORAGE 런타임 권한 필요, Q+는 MediaStore로 권한 불필요
+
+    private fun downloadCard(card: ReadingCard) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
+            ContextCompat.checkSelfPermission(
+                requireContext(),
+                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            pendingDownloadCard = card
+            storagePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            return
+        }
+        saveCardToGallery(card)
+    }
+
+    private fun saveCardToGallery(card: ReadingCard) {
+        val context = requireContext()
+        captureShareableCard(card) { bitmap ->
+            if (bitmap == null) {
+                context.showCustomToast("저장 중 오류가 발생했어요", false)
+                return@captureShareableCard
+            }
+            viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                val saved = saveBitmapToGallery(context, bitmap)
+                bitmap.recycle()
+                withContext(Dispatchers.Main) {
+                    if (!isAdded) return@withContext
+                    if (saved) {
+                        context.showCustomToast("사진을 저장했어요", true)
+                    } else {
+                        context.showCustomToast("사진 저장에 실패했어요", false)
+                    }
+                }
+            }
+        }
+    }
+
+    // 비트맵을 갤러리(Pictures/부키부키)에 저장. 성공 여부 반환
+    private fun saveBitmapToGallery(context: Context, bitmap: Bitmap): Boolean {
+        val resolver = context.contentResolver
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, "bookii_card_${System.currentTimeMillis()}.png")
+            put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/부키부키")
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        }
+
+        val uri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values) ?: return false
+        return try {
+            resolver.openOutputStream(uri)?.use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            } ?: return false
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                values.clear()
+                values.put(MediaStore.Images.Media.IS_PENDING, 0)
+                resolver.update(uri, values, null, null)
+            }
+            true
+        } catch (_: Exception) {
+            resolver.delete(uri, null, null)
+            false
+        }
     }
 
     /** Bookii 브랜드 오렌지 그라데이션 배경 비트맵 (Instagram 스토리 1080×1920) */

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/ReadingCardDetailFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/ReadingCardDetailFragment.kt
@@ -1,6 +1,8 @@
 package com.bookiibookii.bookiibookii.library.feat
 
 import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -24,6 +26,12 @@ import com.bookiibookii.bookiibookii.library.ui.ReadingCard
 import com.bookiibookii.bookiibookii.library.ui.ReadingCardDetailScreen
 import com.bookiibookii.bookiibookii.library.ui.ShareableCard
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+import com.kakao.sdk.share.ShareClient
+import com.kakao.sdk.share.WebSharerClient
+import com.kakao.sdk.template.model.Button
+import com.kakao.sdk.template.model.Content
+import com.kakao.sdk.template.model.FeedTemplate
+import com.kakao.sdk.template.model.Link
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
@@ -75,7 +83,101 @@ class ReadingCardDetailFragment : BaseLibraryFragment() {
                         }
                     },
                     onInstaShare = { card -> shareCardToInstagram(card) },
+                    onCopyLink   = { card -> copyShareLink(card) },
+                    onKakaoShare = { card -> shareToKakao(card) },
+                    onXShare     = { card -> shareToX(card) },
                 )
+            }
+        }
+    }
+
+    // ── 공유 토큰 발급 (링크 복사 / 카카오 / X 공통) ──────────────────────────
+    // POST .../share-token 호출 → 응답 shareUrl을 Main 스레드 콜백으로 전달 (실패 시 null)
+
+    private fun fetchShareUrl(card: ReadingCard, onResult: (String?) -> Unit) {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+            val shareUrl = try {
+                RetrofitClient.libApi().createShareToken(card.cardId).body()?.result?.shareUrl
+            } catch (_: Exception) {
+                null
+            }
+            withContext(Dispatchers.Main) {
+                if (!isAdded) return@withContext
+                onResult(shareUrl)
+            }
+        }
+    }
+
+    // ── 링크 복사 ────────────────────────────────────────────────────────────
+
+    private fun copyShareLink(card: ReadingCard) {
+        val context = requireContext()
+        fetchShareUrl(card) { shareUrl ->
+            if (shareUrl.isNullOrBlank()) {
+                context.showCustomToast("링크 복사에 실패했어요", false)
+            } else {
+                val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clipboard.setPrimaryClip(ClipData.newPlainText("독서카드 링크", shareUrl))
+                context.showCustomToast("링크를 복사했어요", true)
+            }
+        }
+    }
+
+    // ── 카카오톡 공유 (피드 템플릿) ───────────────────────────────────────────
+    // 카카오톡 설치 시 ShareClient, 미설치 시 WebSharerClient(웹) 폴백
+
+    private fun shareToKakao(card: ReadingCard) {
+        val context = requireContext()
+        fetchShareUrl(card) { shareUrl ->
+            if (shareUrl.isNullOrBlank()) {
+                context.showCustomToast("공유에 실패했어요", false)
+                return@fetchShareUrl
+            }
+            val link = Link(webUrl = shareUrl, mobileWebUrl = shareUrl)
+            val feed = FeedTemplate(
+                content = Content(
+                    title = card.bookTitle.ifBlank { "독서카드" },
+                    description = card.quotation.ifBlank { card.content },
+                    imageUrl = card.imageUrl.orEmpty(),
+                    link = link,
+                ),
+                buttons = listOf(Button("보러가기", link)),
+            )
+
+            if (ShareClient.instance.isKakaoTalkSharingAvailable(context)) {
+                ShareClient.instance.shareDefault(context, feed) { result, error ->
+                    when {
+                        error != null -> context.showCustomToast("공유에 실패했어요", false)
+                        result != null -> startActivity(result.intent)
+                    }
+                }
+            } else {
+                // 카카오톡 미설치 → 웹 공유 폴백
+                try {
+                    startActivity(Intent(Intent.ACTION_VIEW, WebSharerClient.instance.makeDefaultUrl(feed)))
+                } catch (_: Exception) {
+                    context.showCustomToast("카카오톡을 열 수 없어요", false)
+                }
+            }
+        }
+    }
+
+    // ── X 공유 (작성화면 인텐트) ──────────────────────────────────────────────
+
+    private fun shareToX(card: ReadingCard) {
+        val context = requireContext()
+        fetchShareUrl(card) { shareUrl ->
+            if (shareUrl.isNullOrBlank()) {
+                context.showCustomToast("공유에 실패했어요", false)
+                return@fetchShareUrl
+            }
+            val text = card.bookTitle.ifBlank { "독서카드" }
+            val intentUrl = "https://twitter.com/intent/tweet?text=" +
+                Uri.encode(text) + "&url=" + Uri.encode(shareUrl)
+            try {
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(intentUrl)))
+            } catch (_: Exception) {
+                context.showCustomToast("X를 열 수 없어요", false)
             }
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/ReadingCardDetailFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/feat/ReadingCardDetailFragment.kt
@@ -224,7 +224,8 @@ class ReadingCardDetailFragment : BaseLibraryFragment() {
             }
         }
 
-        val container = (requireView().parent as? ViewGroup) ?: run {
+        // FragmentContainerView에는 Fragment 미연결 View를 못 붙이므로 액티비티 content 루트에 부착
+        val container = requireActivity().findViewById<ViewGroup>(android.R.id.content) ?: run {
             onBitmap(null)
             return
         }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/PublicCardViewerScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/PublicCardViewerScreen.kt
@@ -1,0 +1,193 @@
+package com.bookiibookii.bookiibookii.library.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.R
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 공유 토큰으로 진입하는 공개 독서카드 뷰어 (로그인 불필요, stateless)
+// - 카드 비주얼은 기존 ShareableCard 재사용 → PHOTO/QUOTE 타입별 디자인이 그대로 분기됨
+// - 상단 로고 / 가운데 카드 / 책 정보 / 하단 CTA(앱에서 보기)
+@Composable
+fun PublicCardViewerScreen(
+    card: ReadingCard,
+    bookAuthor: String = "",
+    onClose: () -> Unit = {},
+    onOpenApp: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(BookiiBookiiTheme.colors.uiBg)
+            .statusBarsPadding(),
+    ) {
+        // 상단 바 — 닫기 + 가운데 로고
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp)
+                .padding(horizontal = 16.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .clickable(onClick = onClose),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_x),
+                    contentDescription = "닫기",
+                    tint = BookiiBookiiTheme.colors.grey900,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+            Icon(
+                painter = painterResource(R.drawable.ic_bookii_text),
+                contentDescription = null,
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .height(14.dp),
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 카드 — 공유용과 동일 비율(348:464), 타입별 디자인은 ShareableCard가 분기
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.8f)
+                    .aspectRatio(348f / 464f),
+            ) {
+                ShareableCard(card = card, modifier = Modifier.fillMaxSize())
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // 책 제목
+            Text(
+                text = card.bookTitle,
+                style = BookiiBookiiTheme.typography.semibold18,
+                color = BookiiBookiiTheme.colors.grey900,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            // 저자
+            if (bookAuthor.isNotBlank()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = bookAuthor,
+                    style = BookiiBookiiTheme.typography.regular14,
+                    color = BookiiBookiiTheme.colors.grey500,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            // 작성자
+            if (card.username.isNotBlank()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "${card.username} 님의 독서카드",
+                    style = BookiiBookiiTheme.typography.regular14,
+                    color = BookiiBookiiTheme.colors.grey600,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        // 하단 CTA — 앱에서 보기
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .clip(BookiiBookiiTheme.shape.round16)
+                .background(BookiiBookiiTheme.colors.uiMain)
+                .clickable(onClick = onOpenApp)
+                .padding(vertical = 16.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "부키부키 앱에서 보기",
+                style = BookiiBookiiTheme.typography.medium16,
+                color = BookiiBookiiTheme.colors.white,
+            )
+        }
+    }
+}
+
+@Preview(name = "공개 뷰어 - 인용구", widthDp = 412, heightDp = 917, showBackground = true)
+@Composable
+private fun PublicCardViewerQuotePreview() {
+    BookiiPreview {
+        PublicCardViewerScreen(
+            card = ReadingCard(
+                username = "북이",
+                content = "다시 읽어도 마음에 오래 남는 문장이었다.",
+                page = "123",
+                type = ReadingCardType.QUOTE,
+                bookTitle = "데미안",
+                quotation = "새는 알에서 나오려고 투쟁한다.",
+            ),
+            bookAuthor = "헤르만 헤세",
+        )
+    }
+}
+
+@Preview(name = "공개 뷰어 - 이미지", widthDp = 412, heightDp = 917, showBackground = true)
+@Composable
+private fun PublicCardViewerPhotoPreview() {
+    BookiiPreview {
+        PublicCardViewerScreen(
+            card = ReadingCard(
+                username = "부키",
+                content = "이 장면이 특히 인상 깊었어요.",
+                page = "45",
+                type = ReadingCardType.PHOTO,
+                bookTitle = "어린 왕자",
+            ),
+            bookAuthor = "생텍쥐페리",
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/PublicCardViewerScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/PublicCardViewerScreen.kt
@@ -149,7 +149,7 @@ fun PublicCardViewerScreen(
             contentAlignment = Alignment.Center,
         ) {
             Text(
-                text = "부키부키 앱에서 보기",
+                text = "부키부키 앱으로 이동하기",
                 style = BookiiBookiiTheme.typography.medium16,
                 color = BookiiBookiiTheme.colors.white,
             )

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/ReadingCardDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/ReadingCardDetailScreen.kt
@@ -144,6 +144,7 @@ fun ReadingCardDetailScreen(
     onCopyLink: (card: ReadingCard) -> Unit = {},
     onKakaoShare: (card: ReadingCard) -> Unit = {},
     onXShare: (card: ReadingCard) -> Unit = {},
+    onDownload: (card: ReadingCard) -> Unit = {},
 ) {
     val pagerState    = rememberPagerState(initialPage = initialIndex) { cards.size }
     val coroutineScope = rememberCoroutineScope()
@@ -274,6 +275,10 @@ fun ReadingCardDetailScreen(
             onXClick = {
                 showShareSheet = false
                 currentCard?.let { onXShare(it) }
+            },
+            onDownloadClick = {
+                showShareSheet = false
+                currentCard?.let { onDownload(it) }
             },
             onCopyLinkClick = {
                 showShareSheet = false

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/ReadingCardDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/ReadingCardDetailScreen.kt
@@ -141,6 +141,9 @@ fun ReadingCardDetailScreen(
     onBookmarkToggle: (cardId: Long) -> Unit = {},
     onReactionToggle: (cardId: Long, reaction: String) -> Unit = { _, _ -> },
     onInstaShare: (card: ReadingCard) -> Unit = {},
+    onCopyLink: (card: ReadingCard) -> Unit = {},
+    onKakaoShare: (card: ReadingCard) -> Unit = {},
+    onXShare: (card: ReadingCard) -> Unit = {},
 ) {
     val pagerState    = rememberPagerState(initialPage = initialIndex) { cards.size }
     val coroutineScope = rememberCoroutineScope()
@@ -260,9 +263,21 @@ fun ReadingCardDetailScreen(
     if (showShareSheet) {
         ReadingCardShareBottomSheet(
             onDismiss    = { showShareSheet = false },
+            onKakaoClick = {
+                showShareSheet = false
+                currentCard?.let { onKakaoShare(it) }
+            },
             onInstaClick = {
                 showShareSheet = false
                 currentCard?.let { onInstaShare(it) }
+            },
+            onXClick = {
+                showShareSheet = false
+                currentCard?.let { onXShare(it) }
+            },
+            onCopyLinkClick = {
+                showShareSheet = false
+                currentCard?.let { onCopyLink(it) }
             },
         )
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/ReadingCardDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/ui/ReadingCardDetailScreen.kt
@@ -60,7 +60,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
@@ -639,7 +641,16 @@ internal fun ShareableCard(card: ReadingCard, modifier: Modifier = Modifier) {
                 Box(modifier = Modifier.fillMaxSize()) {
                     Box(modifier = Modifier.fillMaxSize().background(BookiiBookiiTheme.colors.grey300)) {
                         if (!card.imageUrl.isNullOrBlank()) {
-                            AsyncImage(model = card.imageUrl, contentDescription = null, contentScale = ContentScale.Crop, modifier = Modifier.matchParentSize())
+                            // allowHardware(false): 소프트웨어 Canvas로 캡처(공유/다운로드)하려면 하드웨어 비트맵 비활성 필요
+                            AsyncImage(
+                                model = ImageRequest.Builder(LocalContext.current)
+                                    .data(card.imageUrl)
+                                    .allowHardware(false)
+                                    .build(),
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.matchParentSize(),
+                            )
                         }
                     }
                     Box(

--- a/app/src/main/java/com/bookiibookii/bookiibookii/library/vm/CardMapper.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/library/vm/CardMapper.kt
@@ -1,6 +1,7 @@
 package com.bookiibookii.bookiibookii.library.vm
 
 import com.bookiibookii.bookiibookii.data.model.library.MemberCardResponseDTO
+import com.bookiibookii.bookiibookii.data.model.library.PublicReadingCardResponseDTO
 import com.bookiibookii.bookiibookii.library.ui.ReadingCard
 import com.bookiibookii.bookiibookii.library.ui.ReadingCardType
 
@@ -22,4 +23,18 @@ internal fun MemberCardResponseDTO.toReadingCard() = ReadingCard(
     reactionCounts         = reactionCounts.associate { it.reaction to it.count },
     creatorProfileImageUrl = creatorProfileImageUrl,
     isMine                 = isMine,
+)
+
+/**
+ * 공유 토큰 공개 조회 DTO → UI 모델 변환.
+ * 공개 응답엔 cardId/북마크/리액션이 없어 기본값 사용. 작성자=creatorNickname.
+ */
+internal fun PublicReadingCardResponseDTO.toReadingCard() = ReadingCard(
+    username  = creatorNickname.orEmpty(),
+    content   = memo.orEmpty(),
+    page      = page?.toString().orEmpty(),
+    type      = if (cardType == "IMAGE") ReadingCardType.PHOTO else ReadingCardType.QUOTE,
+    bookTitle = bookTitle.orEmpty(),
+    quotation = quotation.orEmpty(),
+    imageUrl  = imageUrl,
 )

--- a/app/src/main/java/com/bookiibookii/bookiibookii/mypage/feat/main/ProfileSettingFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/mypage/feat/main/ProfileSettingFragment.kt
@@ -1,7 +1,8 @@
 package com.bookiibookii.bookiibookii.mypage.feat.main
 
 import android.Manifest
-import android.content.ContentValues
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
@@ -9,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
@@ -105,22 +107,40 @@ class ProfileSettingFragment : BaseMypageFragment() {
     }
 
     private fun launchCamera() {
-        // insert가 null을 반환하면(저장공간 부족·MediaStore 오류 등) NPE 대신 안내 후 중단
         val uri = createCameraUri()
         if (uri == null) {
             requireContext().showCustomToast("카메라를 실행할 수 없습니다. 잠시 후 다시 시도해주세요.", false)
             return
         }
         cameraImageUri = uri
+        // FileProvider URI에 카메라 앱이 결과를 쓸 수 있도록 임시 쓰기 권한 부여
+        val captureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        requireContext().packageManager
+            .queryIntentActivities(captureIntent, PackageManager.MATCH_DEFAULT_ONLY)
+            .forEach { info ->
+                requireContext().grantUriPermission(
+                    info.activityInfo.packageName,
+                    uri,
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
         takePictureLauncher.launch(uri)
     }
 
+    // 카메라 출력 = 앱 내부 캐시(cache/camera) 파일의 FileProvider URI.
+    // MediaStore(공용 갤러리)에 넣지 않으므로 촬영본이 갤러리에 남지 않는다.
     private fun createCameraUri(): Uri? {
-        val values = ContentValues().apply {
-            put(MediaStore.Images.Media.DISPLAY_NAME, "profile_${System.currentTimeMillis()}.jpg")
-            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        return try {
+            val cameraDir = File(requireContext().cacheDir, "camera").apply { mkdirs() }
+            val file = File(cameraDir, "profile_${System.currentTimeMillis()}.jpg")
+            FileProvider.getUriForFile(
+                requireContext(),
+                "${requireContext().packageName}.fileprovider",
+                file,
+            )
+        } catch (e: Exception) {
+            null
         }
-        return requireContext().contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
     }
 
     // 원본 이미지를 임시 파일로 복사 (EXIF 보존).

--- a/app/src/main/java/com/bookiibookii/bookiibookii/mypage/feat/main/ProfileSettingFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/mypage/feat/main/ProfileSettingFragment.kt
@@ -2,8 +2,6 @@ package com.bookiibookii.bookiibookii.mypage.feat.main
 
 import android.Manifest
 import android.content.ContentValues
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
@@ -39,7 +37,7 @@ class ProfileSettingFragment : BaseMypageFragment() {
         if (success) {
             cameraImageUri?.let { uri ->
                 selectedImageUri.value = uri
-                selectedImageFile = createCompressedImageFile(uri)
+                selectedImageFile = createUploadTempFile(uri)
             }
         }
     }
@@ -52,7 +50,7 @@ class ProfileSettingFragment : BaseMypageFragment() {
     private val pickMediaLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         uri?.let {
             selectedImageUri.value = it
-            selectedImageFile = createCompressedImageFile(it)
+            selectedImageFile = createUploadTempFile(it)
         }
     }
 
@@ -125,32 +123,14 @@ class ProfileSettingFragment : BaseMypageFragment() {
         return requireContext().contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
     }
 
-    private fun createCompressedImageFile(uri: Uri): File? {
+    // 원본 이미지를 임시 파일로 복사 (EXIF 보존).
+    // 리사이즈/압축/EXIF 회전 적용은 업로드 시 S3Uploader가 처리
+    private fun createUploadTempFile(uri: Uri): File? {
         return try {
-            val bitmap = requireContext().contentResolver.openInputStream(uri)?.use { stream ->
-                BitmapFactory.decodeStream(stream)
-            } ?: return null
-
-            val maxPx = 1600
-            val scaled = if (bitmap.width > maxPx || bitmap.height > maxPx) {
-                val ratio = maxPx.toFloat() / maxOf(bitmap.width, bitmap.height)
-                val w = (bitmap.width * ratio).toInt()
-                val h = (bitmap.height * ratio).toInt()
-                Bitmap.createScaledBitmap(bitmap, w, h, true).also { bitmap.recycle() }
-            } else {
-                bitmap
-            }
-
             val tempFile = File.createTempFile("profile_", ".jpg", requireContext().cacheDir)
-            var quality = 80
-            do {
-                tempFile.outputStream().use { out ->
-                    scaled.compress(Bitmap.CompressFormat.JPEG, quality, out)
-                }
-                quality -= 10
-            } while (tempFile.length() > 1_048_576L && quality > 20)
-
-            scaled.recycle()
+            requireContext().contentResolver.openInputStream(uri)?.use { input ->
+                tempFile.outputStream().use { output -> input.copyTo(output) }
+            } ?: return null
             tempFile
         } catch (e: Exception) {
             null

--- a/app/src/main/java/com/bookiibookii/bookiibookii/mypage/ui/main/ProfileShareDialog.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/mypage/ui/main/ProfileShareDialog.kt
@@ -49,6 +49,7 @@ import coil.compose.AsyncImage
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.data.model.mypage.UserBookDto
 import com.bookiibookii.bookiibookii.ui.component.ProfilePlaceholder
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 
 @Composable
 fun ProfileShareDialog(
@@ -446,8 +447,32 @@ private fun ShareActionItem(
     }
 }
 
-@Preview(showBackground = true)
+// Preview용 더미 대표책 (이미지 없음 → grey200 placeholder로 렌더)
+private val previewBooks: List<UserBookDto> = List(5) { index ->
+    UserBookDto(title = "책 제목 ${index + 1}", auth = "저자", image = null)
+}
+
+@Preview(name = "다이얼로그(라이트)", widthDp = 412, heightDp = 917, showBackground = true)
 @Composable
 private fun ProfileShareDialogLightPreview() {
-    ProfileShareDialog(name = "김스카이", motto = "역시나 누군가를 사랑하고\n사랑해야 할 당신을 위해")
+    BookiiPreview {
+        ProfileShareDialog(
+            name = "김스카이",
+            motto = "역시나 누군가를 사랑하고\n사랑해야 할 당신을 위해",
+            representativeBooks = previewBooks,
+        )
+    }
+}
+
+@Preview(name = "카드 콘텐츠(다크)", widthDp = 412, showBackground = true)
+@Composable
+private fun ProfileShareCardContentDarkPreview() {
+    BookiiPreview {
+        ProfileShareCardContent(
+            name = "김스카이",
+            motto = "역시나 누군가를 사랑하고\n사랑해야 할 당신을 위해",
+            representativeBooks = previewBooks,
+            isDark = true,
+        )
+    }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/mypage/vm/MypageViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/mypage/vm/MypageViewModel.kt
@@ -6,17 +6,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bookiibookii.bookiibookii.data.api.RetrofitClient
+import com.bookiibookii.bookiibookii.data.api.S3Uploader
 import com.bookiibookii.bookiibookii.data.model.mypage.MypageReqDTO
 import com.bookiibookii.bookiibookii.data.model.mypage.UpdateIntroductionReqDTO
 import com.bookiibookii.bookiibookii.data.model.mypage.UserProfileResDTO
 import com.bookiibookii.bookiibookii.onboarding.steps.model.NicknameCheckState
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
 
 class MypageViewModel : ViewModel() {
@@ -143,21 +140,9 @@ class MypageViewModel : ViewModel() {
                             val uploadUrl = result.presignedPutUrl
                             val issuedS3Key = result.s3Key
 
-                            val mimeType = "image/jpeg"
-                            val requestBody = imageFile.asRequestBody(mimeType.toMediaTypeOrNull())
-                            val cleanClient = okhttp3.OkHttpClient()
-
-                            val requestS3 = okhttp3.Request.Builder()
-                                .url(uploadUrl)
-                                .put(requestBody)
-                                .addHeader("Content-Type", mimeType)
-                                .build()
-
-                            val uploadRes = withContext(Dispatchers.IO) {
-                                cleanClient.newCall(requestS3).execute()
-                            }
-
-                            if (!uploadRes.isSuccessful) {
+                            // S3 업로드 통일 — 리사이즈/압축(≤1MB) 자동 적용
+                            val uploadResult = S3Uploader.uploadImage(imageFile, uploadUrl)
+                            if (uploadResult.isFailure) {
                                 _eventFlow.emit(Event.ShowToast("이미지 업로드에 실패했습니다.", false))
                                 return@launch
                             }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/OnbStepActivity.kt
@@ -1,14 +1,15 @@
 package com.bookiibookii.bookiibookii.onboarding.steps
 
 import android.Manifest
-import android.content.ContentValues
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.setContent
+import androidx.core.content.FileProvider
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -101,13 +102,23 @@ class OnbStepActivity : AppCompatActivity() {
     }
 
     private fun launchCamera() {
-        // insert가 null을 반환하면(저장공간 부족·MediaStore 오류 등) NPE 대신 안내 후 중단
         val uri = createCameraImageUri()
         if (uri == null) {
             Toast.makeText(this, "카메라를 실행할 수 없습니다. 잠시 후 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
             return
         }
         cameraImageUri = uri
+        // FileProvider URI에 카메라 앱이 결과를 쓸 수 있도록 임시 쓰기 권한 부여
+        val captureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        packageManager
+            .queryIntentActivities(captureIntent, PackageManager.MATCH_DEFAULT_ONLY)
+            .forEach { info ->
+                grantUriPermission(
+                    info.activityInfo.packageName,
+                    uri,
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
         takePictureLauncher.launch(uri)
     }
 
@@ -128,11 +139,15 @@ class OnbStepActivity : AppCompatActivity() {
         }
     }
 
+    // 카메라 출력 = 앱 내부 캐시(cache/camera) 파일의 FileProvider URI.
+    // MediaStore(공용 갤러리)에 넣지 않으므로 촬영본이 갤러리에 남지 않는다.
     private fun createCameraImageUri(): Uri? {
-        val values = ContentValues().apply {
-            put(MediaStore.Images.Media.DISPLAY_NAME, "profile_${System.currentTimeMillis()}.jpg")
-            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+        return try {
+            val cameraDir = File(cacheDir, "camera").apply { mkdirs() }
+            val file = File(cameraDir, "profile_${System.currentTimeMillis()}.jpg")
+            FileProvider.getUriForFile(this, "$packageName.fileprovider", file)
+        } catch (e: Exception) {
+            null
         }
-        return contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/model/TrackerDetailMapper.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/model/TrackerDetailMapper.kt
@@ -40,7 +40,7 @@ private fun String?.toPhaseLabel(): String = when (this) {
     "MY_BOOK_READING", "MY_BOOK_REVIEWING" -> "내 책 읽기"
     "EXCHANGING", "EXCHANGED" -> "교환"
     "PARTNER_BOOK_READING", "PARTNER_BOOK_REVIEWING" -> "파트너 책 읽기"
-    "RETURNING", "COMPLETED", null -> "반납"
+    "RETURNING", "RETURNED", "COMPLETED", null -> "반납"
     else -> ""
 }
 


### PR DESCRIPTION
# 📌 Pull Request Title
> - feat: 독서카드 공유 기능 1차 구현

---

# ✨ 작업 내용 (What)
> - 독서카드 인스타 공유, 다운로드 기능 구현
> - 카카오, url 링크 공유 웹 연결만
> - 앱 내 카메라 촬영 시 기기 저장 안함

---

# 💡추가 사항
> - 독서카드 공유 디자인 확인 필요
> - 독서카드 공유 로직 추후 재확인 

---

# 🔗 관련 이슈 (Optional)
- close #364
