### PR TITLE
feat: 홈 화면 ui 및 그룹 진입 구현 (#374)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/HomeGroups.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/data/model/group/HomeGroups.kt
@@ -4,25 +4,36 @@ import com.google.gson.annotations.SerializedName
 
 // GET /api/groups/home 응답 result
 data class HomeGroupsResponse(
-    @SerializedName("newGroups") val newGroups: List<GroupItem> = emptyList(),
-    @SerializedName("categorySection") val categorySection: HomeCategorySection? = null,
-    @SerializedName("bestsellerSection") val bestsellerSection: HomeBestsellerSection? = null,
-    @SerializedName("regionSection") val regionSection: HomeRegionSection? = null,
+    @SerializedName("sections") val sections: List<HomeSection> = emptyList(),
+)
+data class HomeSection(
+    @SerializedName("sectionType") val sectionType: String,
+    @SerializedName("title") val title: String,
+    @SerializedName("subtitle") val subtitle: String,
+    @SerializedName("layoutType") val layoutType: String,
+    @SerializedName("items") val items: List<HomeSectionItem> = emptyList(),
 )
 
-// 카테고리 기반 섹션 — category=null이면 추천 불가
-data class HomeCategorySection(
-    @SerializedName("category") val category: String?,
-    @SerializedName("groups") val groups: List<GroupItem> = emptyList(),
+data class HomeSectionItem(
+    // 공통
+    @SerializedName("author") val author: String? = null,
+    @SerializedName("bookImage") val bookImage: String? = null,
+    // 책 항목
+    @SerializedName("isbn13") val isbn13: String? = null,
+    @SerializedName("title") val title: String? = null,
+    @SerializedName("searchKeyword") val searchKeyword: String? = null,
+    @SerializedName("rank") val rank: Int? = null,
+    // 그룹 항목
+    @SerializedName("groupId") val groupId: Long? = null,
+    @SerializedName("groupName") val groupName: String? = null,
+    @SerializedName("hostNickname") val hostNickname: String? = null,
+    @SerializedName("hostProfileImageUrl") val hostProfileImageUrl: String? = null,
+    @SerializedName("bookTitle") val bookTitle: String? = null,
+    @SerializedName("readingPeriod") val readingPeriod: Int? = null,
 )
 
-// 베스트셀러 기반 섹션
-data class HomeBestsellerSection(
-    @SerializedName("groups") val groups: List<GroupItem> = emptyList(),
-)
-
-// 교환 지역 기반 섹션 — region=null이면 교환 장소 미설정
-data class HomeRegionSection(
-    @SerializedName("region") val region: String?,
-    @SerializedName("groups") val groups: List<GroupItem> = emptyList(),
-)
+object HomeLayoutType {
+    const val GROUP_CARD_CAROUSEL = "GROUP_CARD_CAROUSEL"
+    const val BOOK_THUMBNAIL_CAROUSEL = "BOOK_THUMBNAIL_CAROUSEL"
+    const val BOOK_THUMBNAIL_GRID = "BOOK_THUMBNAIL_GRID"
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupDestinations.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupDestinations.kt
@@ -1,13 +1,21 @@
 package com.bookiibookii.bookiibookii.group.nav
 
+import android.net.Uri
+
 object GroupDestinations {
 
     const val ARG_GROUP_ID = "groupId"
+    const val ARG_KEYWORD = "keyword"
 
-    const val SEARCH = "search"
+    // keyword는 선택 인자 — 있으면 진입 시 해당 검색어로 검색(홈에서 책 탭)
+    const val SEARCH = "search?$ARG_KEYWORD={$ARG_KEYWORD}"
     const val DETAIL = "detail/{$ARG_GROUP_ID}"
     const val EDITOR = "editor?$ARG_GROUP_ID={$ARG_GROUP_ID}"
     const val JOIN_REQUESTS = "joinRequests/{$ARG_GROUP_ID}"
+
+    // keyword == null/blank -> 일반 진입, 아니면 검색어 프리필 진입
+    fun search(keyword: String? = null) =
+        if (keyword.isNullOrBlank()) "search" else "search?$ARG_KEYWORD=${Uri.encode(keyword)}"
 
     fun detail(groupId: Long) = "detail/$groupId"
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/nav/GroupNavHost.kt
@@ -33,7 +33,17 @@ fun GroupNavHost(
         popEnterTransition = { EnterTransition.None },
         popExitTransition = { ExitTransition.None },
     ) {
-        composable(GroupDestinations.SEARCH) {
+        composable(
+            route = GroupDestinations.SEARCH,
+            arguments = listOf(
+                navArgument(GroupDestinations.ARG_KEYWORD) {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                },
+            ),
+        ) {
+            // keyword 인자는 GroupSearchViewModel이 SavedStateHandle로 직접 수신
             GroupSearchRoute(
                 // 백스택이 있으면 이전 화면으로, 없으면(홈에서 직접 진입) 그룹 도메인 밖으로 나감
                 onBack = { if (!navController.popBackStack()) onExit() },
@@ -98,7 +108,7 @@ fun GroupNavHost(
                 },
                 // 삭제 성공 → 그룹 목록으로 이동, 삭제된 상세는 백스택에서 제거
                 onDeleted = {
-                    navController.navigate(GroupDestinations.SEARCH) {
+                    navController.navigate(GroupDestinations.search()) {
                         popUpTo(GroupDestinations.SEARCH) { inclusive = true }
                         launchSingleTop = true
                     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupSearchViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupSearchViewModel.kt
@@ -1,22 +1,28 @@
 package com.bookiibookii.bookiibookii.group.vm
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.bookiibookii.bookiibookii.data.api.RetrofitClient
 import com.bookiibookii.bookiibookii.data.model.group.GroupItem
 import com.bookiibookii.bookiibookii.group.model.GroupSearchUiState
+import com.bookiibookii.bookiibookii.group.nav.GroupDestinations
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-class GroupSearchViewModel : ViewModel() {
+class GroupSearchViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
 
     private val _state = MutableStateFlow(GroupSearchUiState())
     val state: StateFlow<GroupSearchUiState> = _state
 
     init {
-        // 진입 시 기본값(전체)으로 목록 로드
+        // 검색어 인자(예: 홈에서 책 탭)가 있으면 검색 모드로 시작, 없으면 기본 목록
+        val keyword = savedStateHandle.get<String>(GroupDestinations.ARG_KEYWORD).orEmpty().trim()
+        if (keyword.isNotEmpty()) {
+            _state.update { it.copy(query = keyword, searchKeyword = keyword) }
+        }
         load()
     }
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/HomeFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/HomeFragment.kt
@@ -63,6 +63,16 @@ class HomeFragment : Fragment() {
                             .addToBackStack(null)
                             .commit()
                     },
+                    // 책 탭 → 해당 책 제목으로 그룹 검색 진입
+                    onBookClick = { keyword ->
+                        parentFragmentManager.beginTransaction()
+                            .replace(
+                                R.id.fragmentContainer,
+                                GroupFragment.newInstance(GroupDestinations.search(keyword)),
+                            )
+                            .addToBackStack(null)
+                            .commit()
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/HomeViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/HomeViewModel.kt
@@ -6,9 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.bookiibookii.bookiibookii.data.api.RetrofitClient
 import com.bookiibookii.bookiibookii.data.model.group.GroupItem
-import com.bookiibookii.bookiibookii.data.model.group.HomeBestsellerSection
-import com.bookiibookii.bookiibookii.data.model.group.HomeCategorySection
-import com.bookiibookii.bookiibookii.data.model.group.HomeRegionSection
+import com.bookiibookii.bookiibookii.data.model.group.HomeSection
 import com.bookiibookii.bookiibookii.onboarding.login.TokenManager
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,10 +20,7 @@ enum class HomeTab { RECOMMEND, MY_GROUPS, APPLIED }
 data class HomeUiState(
     val nickname: String = "",
     val selectedTab: HomeTab = HomeTab.RECOMMEND,
-    val newGroups: List<GroupItem> = emptyList(),
-    val categorySection: HomeCategorySection? = null,
-    val bestsellerSection: HomeBestsellerSection? = null,
-    val regionSection: HomeRegionSection? = null,
+    val recommendSections: List<HomeSection> = emptyList(),
     val myGroups: List<GroupItem> = emptyList(),
     val appliedGroups: List<GroupItem> = emptyList(),
     val hasNewNotification: Boolean = false,
@@ -73,14 +68,7 @@ class HomeViewModel(app: Application) : AndroidViewModel(app) {
                 RetrofitClient.grpApi().getHomeGroups()
             }.onSuccess { response ->
                 val result = response.body()?.result ?: return@onSuccess
-                _uiState.update {
-                    it.copy(
-                        newGroups = result.newGroups,
-                        categorySection = result.categorySection,
-                        bestsellerSection = result.bestsellerSection,
-                        regionSection = result.regionSection,
-                    )
-                }
+                _uiState.update { it.copy(recommendSections = result.sections) }
             }
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/HomeScreen.kt
@@ -49,6 +49,7 @@ fun HomeRoute(
     onCreateGroupClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onProfileClick: () -> Unit,
+    onBookClick: (String) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     HomeScreen(
@@ -59,6 +60,8 @@ fun HomeRoute(
         onCreateGroupClick = onCreateGroupClick,
         onNotificationClick = onNotificationClick,
         onProfileClick = onProfileClick,
+        // 책 탭 → 그 책 제목(searchKeyword)으로 그룹 검색
+        onBookClick = { item -> onBookClick(item.searchKeyword ?: item.title.orEmpty()) },
     )
 }
 
@@ -74,6 +77,7 @@ internal fun HomeScreen(
     onCreateGroupClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onProfileClick: () -> Unit,
+    onBookClick: (HomeSectionItem) -> Unit = {},
 ) {
     val lazyListState = rememberLazyListState()
 
@@ -147,6 +151,7 @@ internal fun HomeScreen(
                 HomeTab.RECOMMEND -> homeRecommendContent(
                     sections = uiState.recommendSections,
                     onGroupClick = onGroupClick,
+                    onBookClick = onBookClick,
                 )
                 HomeTab.MY_GROUPS -> homeMyGroupsContent(
                     myGroups = uiState.myGroups,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/HomeScreen.kt
@@ -23,7 +23,9 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.bookiibookii.bookiibookii.data.model.group.GroupItem
+import com.bookiibookii.bookiibookii.data.model.group.HomeLayoutType
+import com.bookiibookii.bookiibookii.data.model.group.HomeSection
+import com.bookiibookii.bookiibookii.data.model.group.HomeSectionItem
 import com.bookiibookii.bookiibookii.home.HomeTab
 import com.bookiibookii.bookiibookii.home.HomeUiState
 import com.bookiibookii.bookiibookii.home.HomeViewModel
@@ -143,10 +145,7 @@ internal fun HomeScreen(
 
             when (uiState.selectedTab) {
                 HomeTab.RECOMMEND -> homeRecommendContent(
-                    newGroups = uiState.newGroups,
-                    categorySection = uiState.categorySection,
-                    bestsellerSection = uiState.bestsellerSection,
-                    regionSection = uiState.regionSection,
+                    sections = uiState.recommendSections,
                     onGroupClick = onGroupClick,
                 )
                 HomeTab.MY_GROUPS -> homeMyGroupsContent(
@@ -166,16 +165,22 @@ internal fun HomeScreen(
 
 // ─── 프리뷰 ───────────────────────────────────────────────────────────────────
 
-private val mockGroupItem = GroupItem(
-    groupId = 1L, groupName = "책과 함께", title = "살인자의 기억법", author = "김영하",
-    genre = "한국소설", bookImage = null, hostNickname = "부키", hostProfileImageUrl = null,
-    groupStatus = "RECRUITING", currentCount = 2, maxCapacity = 5, waitingCount = 0,
-    isHot = false, tradeType = "직접", readingPeriod = 7, pictureBadge = null,
+private val mockGroupItem = HomeSectionItem(
+    groupId = 1L, groupName = "책과 함께", bookTitle = "살인자의 기억법", author = "김영하",
+    bookImage = null, hostNickname = "부키", hostProfileImageUrl = null, readingPeriod = 7,
 )
-private val mockNewGroups = listOf(
-    mockGroupItem,
-    mockGroupItem.copy(groupId = 2L, title = "채식주의자"),
-    mockGroupItem.copy(groupId = 3L, title = "아몬드"),
+private val mockSections = listOf(
+    HomeSection(
+        sectionType = "NEW_GROUPS",
+        title = "신규 그룹을 확인해보세요.",
+        subtitle = "오늘 만들어진 따끈따끈한 그룹들만 모았어요.",
+        layoutType = HomeLayoutType.GROUP_CARD_CAROUSEL,
+        items = listOf(
+            mockGroupItem,
+            mockGroupItem.copy(groupId = 2L, bookTitle = "채식주의자"),
+            mockGroupItem.copy(groupId = 3L, bookTitle = "아몬드"),
+        ),
+    ),
 )
 
 @Preview(showBackground = true, name = "HomeScreen - 추천 탭")
@@ -186,7 +191,7 @@ private fun HomeScreenRecommendPreview() {
             uiState = HomeUiState(
                 nickname = "부키유저",
                 selectedTab = HomeTab.RECOMMEND,
-                newGroups = mockNewGroups,
+                recommendSections = mockSections,
             ),
             onTabSelect = {},
             onGroupClick = {},
@@ -206,7 +211,7 @@ private fun HomeScreenRecommendEmptyPreview() {
             uiState = HomeUiState(
                 nickname = "부키유저",
                 selectedTab = HomeTab.RECOMMEND,
-                newGroups = emptyList(),
+                recommendSections = emptyList(),
             ),
             onTabSelect = {},
             onGroupClick = {},

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeRecommendBookSections.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeRecommendBookSections.kt
@@ -1,0 +1,146 @@
+package com.bookiibookii.bookiibookii.home.ui.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bookiibookii.bookiibookii.data.model.group.HomeSectionItem
+import com.bookiibookii.bookiibookii.ui.component.BookCover
+import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
+import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
+
+// 캐러셀/그리드 공용. 너비는 호출처에서 modifier로 지정
+@Composable
+internal fun BookThumbnail(
+    book: HomeSectionItem,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val colors = BookiiBookiiTheme.colors
+    val typography = BookiiBookiiTheme.typography
+    Column(
+        modifier = modifier.clickable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        BookCover(
+            imageUrl = book.bookImage,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(120f / 168f),
+        )
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = book.title.orEmpty(),
+                style = typography.regular14,
+                color = colors.grey900,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = book.author.orEmpty(),
+                style = typography.regular14,
+                color = colors.grey500,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+// 인기 도서 TOP 5 등 — 단순 가로 스크롤(그룹 카드 캐러셀과 달리 snap/페이지 도트 없음).
+@Composable
+internal fun RecommendBookRow(
+    books: List<HomeSectionItem>,
+    onBookClick: (HomeSectionItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier,
+        contentPadding = PaddingValues(start = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(books) { book ->
+            BookThumbnail(
+                book = book,
+                onClick = { onBookClick(book) },
+                modifier = Modifier.width(120.dp),
+            )
+        }
+    }
+}
+
+// 베스트셀러 등 — 스크롤 없는 3열 그리드(열/행 gap 8). 아이템 수만큼 자동 줄바꿈.
+@Composable
+internal fun RecommendBookGrid(
+    books: List<HomeSectionItem>,
+    onBookClick: (HomeSectionItem) -> Unit,
+    modifier: Modifier = Modifier,
+    columns: Int = 3,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        books.chunked(columns).forEach { rowBooks ->
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                rowBooks.forEach { book ->
+                    BookThumbnail(
+                        book = book,
+                        onClick = { onBookClick(book) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                repeat(columns - rowBooks.size) {
+                    Spacer(Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+// ─── 프리뷰 ───────────────────────────────────────────────────────────────────
+
+private val mockBook = HomeSectionItem(
+    isbn13 = "1", title = "소년이 온다", author = "한강", bookImage = null,
+)
+private val mockBooks = listOf(
+    mockBook,
+    mockBook.copy(isbn13 = "2", title = "채식주의자", author = "한강"),
+    mockBook.copy(isbn13 = "3", title = "아몬드", author = "손원평"),
+    mockBook.copy(isbn13 = "4", title = "달러구트 꿈 백화점", author = "이미예"),
+    mockBook.copy(isbn13 = "5", title = "불편한 편의점", author = "김호연"),
+)
+
+@Preview(showBackground = true, name = "RecommendBookRow - 단순 스크롤")
+@Composable
+private fun RecommendBookRowPreview() {
+    BookiiPreview {
+        RecommendBookRow(books = mockBooks, onBookClick = {})
+    }
+}
+
+@Preview(showBackground = true, name = "RecommendBookGrid - 그리드", widthDp = 412)
+@Composable
+private fun RecommendBookGridPreview() {
+    BookiiPreview {
+        RecommendBookGrid(
+            books = mockBooks + mockBook.copy(isbn13 = "6", title = "파과", author = "구병모"),
+            onBookClick = {},
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeRecommendContent.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeRecommendContent.kt
@@ -95,7 +95,7 @@ private fun BookCarouselSection(
         modifier = Modifier
             .fillMaxWidth()
             .background(BookiiBookiiTheme.colors.white)
-            .padding(top = 16.dp, bottom = 16.dp),
+            .padding(top = 16.dp, bottom = 24.dp),
     ) {
         HomeSectionHeader(
             title = section.title,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeRecommendContent.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeRecommendContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,117 +16,36 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bookiibookii.bookiibookii.data.model.group.GroupItem
-import com.bookiibookii.bookiibookii.data.model.group.HomeBestsellerSection
-import com.bookiibookii.bookiibookii.data.model.group.HomeCategorySection
-import com.bookiibookii.bookiibookii.data.model.group.HomeRegionSection
+import com.bookiibookii.bookiibookii.data.model.group.HomeLayoutType
+import com.bookiibookii.bookiibookii.data.model.group.HomeSection
+import com.bookiibookii.bookiibookii.data.model.group.HomeSectionItem
+import com.bookiibookii.bookiibookii.home.ui.component.RecommendBookGrid
+import com.bookiibookii.bookiibookii.home.ui.component.RecommendBookRow
 import com.bookiibookii.bookiibookii.home.ui.component.RecommendGroupRow
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
 internal fun LazyListScope.homeRecommendContent(
-    newGroups: List<GroupItem>,
-    categorySection: HomeCategorySection?,
-    bestsellerSection: HomeBestsellerSection?,
-    regionSection: HomeRegionSection?,
+    sections: List<HomeSection>,
     onGroupClick: (Long) -> Unit,
+    onBookClick: (HomeSectionItem) -> Unit = {},
 ) {
-    // 피그마: 탭 영역 ~ 첫 번째 섹션 사이 8dp 회색 간격
     item { Box(Modifier.fillMaxWidth().height(8.dp)) }
 
-    // ① 신규 그룹 섹션 — 오늘 생성된 그룹 없으면 섹션 미표시
-    if (newGroups.isNotEmpty()) {
-        item {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(BookiiBookiiTheme.colors.white)
-                    .padding(top = 16.dp, bottom = 16.dp),
-            ) {
-                HomeSectionHeader(
-                    title = "신규 그룹을 확인해보세요.",
-                    subtitle = "오늘 만들어진 따끈따끈한 그룹들만 모았어요.",
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 0.dp),
-                )
-                Box(Modifier.height(12.dp))
-                RecommendGroupRow(
-                    groups = newGroups,
-                    onGroupClick = onGroupClick,
-                )
-            }
-        }
+    // 아이템 없는 섹션 + 미지원 레이아웃은 숨김. 나머지는 응답 순서대로 렌더.
+    val visibleSections = sections.filter {
+        it.items.isNotEmpty() && it.layoutType in SUPPORTED_LAYOUTS
     }
 
-    // ② 카테고리 기반 섹션 — category != null 이고 그룹 있을 때만 노출
-    val categoryGroups = categorySection?.groups.orEmpty()
-    if (categorySection?.category != null && categoryGroups.isNotEmpty()) {
-        item { Box(Modifier.fillMaxWidth().height(8.dp)) }
-        item {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(BookiiBookiiTheme.colors.white)
-                    .padding(top = 16.dp, bottom = 16.dp),
-            ) {
-                HomeSectionHeader(
-                    title = "최근 읽은 장르와 비슷해요",
-                    subtitle = "${categorySection.category} 장르 그룹들을 모아봤어요.",
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 0.dp),
-                )
-                Box(Modifier.height(12.dp))
-                RecommendGroupRow(
-                    groups = categoryGroups,
-                    onGroupClick = onGroupClick,
-                )
-            }
+    visibleSections.forEachIndexed { index, section ->
+        if (index > 0) {
+            item { Box(Modifier.fillMaxWidth().height(8.dp)) }
         }
-    }
-
-    // ③ 베스트셀러 기반 섹션 — 그룹 있을 때만 노출
-    val bestsellerGroups = bestsellerSection?.groups.orEmpty()
-    if (bestsellerGroups.isNotEmpty()) {
-        item { Box(Modifier.fillMaxWidth().height(8.dp)) }
         item {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(BookiiBookiiTheme.colors.white)
-                    .padding(top = 16.dp, bottom = 16.dp),
-            ) {
-                HomeSectionHeader(
-                    title = "나 빼고 다 읽은 책 여기 있어요.",
-                    subtitle = "이번 기회에 베스트셀러/스테디셀러 읽어볼까요?",
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 0.dp),
-                )
-                Box(Modifier.height(12.dp))
-                RecommendGroupRow(
-                    groups = bestsellerGroups,
-                    onGroupClick = onGroupClick,
-                )
-            }
-        }
-    }
-
-    // ④ 지역 기반 섹션 — region != null 이고 그룹 있을 때만 노출
-    val regionGroups = regionSection?.groups.orEmpty()
-    if (regionSection?.region != null && regionGroups.isNotEmpty()) {
-        item { Box(Modifier.fillMaxWidth().height(8.dp)) }
-        item {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(BookiiBookiiTheme.colors.white)
-                    .padding(top = 16.dp, bottom = 16.dp),
-            ) {
-                HomeSectionHeader(
-                    title = "${regionSection.region}에서 교환할 수 있는 책",
-                    subtitle = "직접 교환 가능한 그룹들이에요.",
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 0.dp),
-                )
-                Box(Modifier.height(12.dp))
-                RecommendGroupRow(
-                    groups = regionGroups,
-                    onGroupClick = onGroupClick,
-                )
+            when (section.layoutType) {
+                HomeLayoutType.GROUP_CARD_CAROUSEL -> GroupCarouselSection(section, onGroupClick)
+                HomeLayoutType.BOOK_THUMBNAIL_CAROUSEL -> BookCarouselSection(section, onBookClick)
+                HomeLayoutType.BOOK_THUMBNAIL_GRID -> BookGridSection(section, onBookClick)
             }
         }
     }
@@ -133,6 +53,107 @@ internal fun LazyListScope.homeRecommendContent(
     // 하단 여백
     item { Box(Modifier.height(80.dp)) }
 }
+
+private val SUPPORTED_LAYOUTS = setOf(
+    HomeLayoutType.GROUP_CARD_CAROUSEL,
+    HomeLayoutType.BOOK_THUMBNAIL_CAROUSEL,
+    HomeLayoutType.BOOK_THUMBNAIL_GRID,
+)
+
+// 그룹 카드 캐러셀
+@Composable
+private fun GroupCarouselSection(
+    section: HomeSection,
+    onGroupClick: (Long) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BookiiBookiiTheme.colors.white)
+            .padding(top = 16.dp, bottom = 16.dp),
+    ) {
+        HomeSectionHeader(
+            title = section.title,
+            subtitle = section.subtitle,
+            modifier = Modifier.padding(horizontal = 16.dp),
+        )
+        Box(Modifier.height(12.dp))
+        RecommendGroupRow(
+            groups = section.items.map { it.toGroupItem() },
+            onGroupClick = onGroupClick,
+        )
+    }
+}
+
+// 책 썸네일 캐러셀
+@Composable
+private fun BookCarouselSection(
+    section: HomeSection,
+    onBookClick: (HomeSectionItem) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BookiiBookiiTheme.colors.white)
+            .padding(top = 16.dp, bottom = 16.dp),
+    ) {
+        HomeSectionHeader(
+            title = section.title,
+            subtitle = section.subtitle,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+        Spacer(Modifier.height(16.dp))
+        RecommendBookRow(
+            books = section.items,
+            onBookClick = onBookClick,
+        )
+    }
+}
+
+// 책 썸네일 그리드
+@Composable
+private fun BookGridSection(
+    section: HomeSection,
+    onBookClick: (HomeSectionItem) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BookiiBookiiTheme.colors.white)
+            .padding(16.dp),
+    ) {
+        HomeSectionHeader(
+            title = section.title,
+            subtitle = section.subtitle,
+        )
+        Spacer(Modifier.height(16.dp))
+        RecommendBookGrid(
+            books = section.items,
+            onBookClick = onBookClick,
+        )
+    }
+}
+
+// 홈 그룹 아이템 → 추천 카드(GroupItem) 매핑.
+// TODO: 백엔드에 tradeType/genre 추가되면 it.tradeType / it.genre 로 교체.
+private fun HomeSectionItem.toGroupItem(): GroupItem = GroupItem(
+    groupId = groupId ?: 0L,
+    groupName = groupName.orEmpty(),
+    title = bookTitle,
+    author = author,
+    genre = "소설", // 임시 더미
+    bookImage = bookImage,
+    hostNickname = hostNickname,
+    hostProfileImageUrl = hostProfileImageUrl,
+    groupStatus = "",
+    currentCount = 0,
+    maxCapacity = 0,
+    waitingCount = 0,
+    isHot = false,
+    tradeType = "DIRECT", // 임시 더미 (→ "직접" 뱃지)
+    readingPeriod = readingPeriod ?: 0,
+    pictureBadge = null,
+)
 
 @Composable
 private fun HomeSectionHeader(
@@ -161,50 +182,70 @@ private fun HomeSectionHeader(
 
 // ─── 프리뷰 ───────────────────────────────────────────────────────────────────
 
-private val mockGroup = GroupItem(
-    groupId = 1L, groupName = "책과 함께", title = "소년이 온다", author = "한강",
-    genre = "한국소설", bookImage = null, hostNickname = "부키", hostProfileImageUrl = null,
-    groupStatus = "RECRUITING", currentCount = 2, maxCapacity = 5, waitingCount = 0,
-    isHot = false, tradeType = "직접", readingPeriod = 7, pictureBadge = null,
+private val mockGroupItem = HomeSectionItem(
+    groupId = 1L, groupName = "책과 함께", bookTitle = "소년이 온다", author = "한강",
+    bookImage = null, hostNickname = "부키", hostProfileImageUrl = null, readingPeriod = 7,
 )
-private val mockNewGroups = listOf(
-    mockGroup,
-    mockGroup.copy(groupId = 2L, title = "채식주의자"),
-    mockGroup.copy(groupId = 3L, title = "아몬드"),
+private val mockGroupItems = listOf(
+    mockGroupItem,
+    mockGroupItem.copy(groupId = 2L, bookTitle = "채식주의자"),
+    mockGroupItem.copy(groupId = 3L, bookTitle = "아몬드"),
+)
+private val mockBookItem = HomeSectionItem(
+    isbn13 = "1", title = "소년이 온다", author = "한강", bookImage = null,
+)
+private val mockBookItems = listOf(
+    mockBookItem,
+    mockBookItem.copy(isbn13 = "2", title = "채식주의자", author = "한강"),
+    mockBookItem.copy(isbn13 = "3", title = "아몬드", author = "손원평"),
+    mockBookItem.copy(isbn13 = "4", title = "달러구트 꿈 백화점", author = "이미예"),
+    mockBookItem.copy(isbn13 = "5", title = "불편한 편의점", author = "김호연"),
+)
+private val mockSections = listOf(
+    HomeSection(
+        sectionType = "NEW_GROUPS",
+        title = "신규 그룹을 확인해보세요.",
+        subtitle = "오늘 만들어진 따끈따끈한 그룹들만 모았어요.",
+        layoutType = HomeLayoutType.GROUP_CARD_CAROUSEL,
+        items = mockGroupItems,
+    ),
+    HomeSection(
+        sectionType = "POPULAR_BOOKS_TOP5",
+        title = "인기 도서 TOP 5",
+        subtitle = "부키부키에서 핫한 도서를 지금 바로 확인해보세요",
+        layoutType = HomeLayoutType.BOOK_THUMBNAIL_CAROUSEL,
+        items = mockBookItems,
+    ),
+    HomeSection(
+        sectionType = "BESTSELLER_BOOKS",
+        title = "나 빼고 다 읽은 책 여기 있어요.",
+        subtitle = "이번 기회에 베스트셀러를 읽어볼까요?",
+        layoutType = HomeLayoutType.BOOK_THUMBNAIL_GRID,
+        items = mockBookItems + mockBookItem.copy(isbn13 = "6", title = "파과", author = "구병모"),
+    ),
 )
 
-@Preview(showBackground = true, name = "HomeRecommendContent - 전체 섹션")
+@Preview(showBackground = true, name = "HomeRecommendContent - 전체 섹션", heightDp = 1600)
 @Composable
 private fun HomeRecommendContentPreview() {
     BookiiPreview {
         LazyColumn {
             homeRecommendContent(
-                newGroups = mockNewGroups,
-                categorySection = HomeCategorySection(
-                    category = "한국소설",
-                    groups = mockNewGroups,
-                ),
-                bestsellerSection = HomeBestsellerSection(groups = mockNewGroups),
-                regionSection = HomeRegionSection(
-                    region = "인천 남동구",
-                    groups = mockNewGroups,
-                ),
+                sections = mockSections,
                 onGroupClick = {},
+                onBookClick = {},
             )
         }
     }
 }
 
-@Preview(showBackground = true, name = "HomeRecommendContent - 신규만")
+@Preview(showBackground = true, name = "HomeRecommendContent - 빈 상태")
 @Composable
-private fun HomeRecommendContentNewOnlyPreview() {
+private fun HomeRecommendContentEmptyPreview() {
     BookiiPreview {
         LazyColumn {
             homeRecommendContent(
-                newGroups = mockNewGroups,
-                categorySection = null,
-                bestsellerSection = null,
-                regionSection = null,
+                sections = emptyList(),
                 onGroupClick = {},
             )
         }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/content/OnbStep1Content.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/content/OnbStep1Content.kt
@@ -332,8 +332,8 @@ private fun GenderSection(selectedGender: String?, onGenderSelected: (String) ->
             modifier = Modifier.fillMaxWidth().height(48.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            GenderButton("여성", selectedGender == "FEMALE", { onGenderSelected("FEMALE") }, Modifier.width(119.dp))
-            GenderButton("남성", selectedGender == "MALE", { onGenderSelected("MALE") }, Modifier.width(119.dp))
+            GenderButton("여성", selectedGender == "FEMALE", { onGenderSelected("FEMALE") }, Modifier.width(120.dp))
+            GenderButton("남성", selectedGender == "MALE", { onGenderSelected("MALE") }, Modifier.width(120.dp))
             GenderButton("선택 안함", selectedGender == "none", { onGenderSelected("none") }, Modifier.weight(1f))
         }
     }


### PR DESCRIPTION
# 📌 Pull Request Title
> - feat: 홈 화면 ui 및 그룹 진입 구현

---

# ✨ 작업 내용 (What)
> - 썸네일 캐러셀, 그리드 섹션 ui 구현
> - 책 선택 시 검색 화면 진입 구현

---

# 🔗 관련 이슈 (Optional)
- close #374
