### PR TITLE
feat: FCM·인앱 알림 클릭 화면 이동 구현 (#417)

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/MainActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/MainActivity.kt
@@ -20,12 +20,16 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.bookiibookii.bookiibookii.common.BaseActivity
 import com.bookiibookii.bookiibookii.databinding.ActivityMainBinding
 import com.bookiibookii.bookiibookii.group.GroupFragment
+import com.bookiibookii.bookiibookii.group.nav.GroupDestinations
 import com.bookiibookii.bookiibookii.home.HomeFragment
 import com.bookiibookii.bookiibookii.library.feat.LibraryFragment
 import com.bookiibookii.bookiibookii.notification.fcm.FcmTokenRegistrar
+import com.bookiibookii.bookiibookii.notification.nav.NotificationRedirect
+import com.bookiibookii.bookiibookii.notification.nav.NotificationRedirectRouter
 import com.bookiibookii.bookiibookii.onboarding.login.LoginActivity
 import com.bookiibookii.bookiibookii.onboarding.login.TokenManager
 import com.bookiibookii.bookiibookii.tracker.TrackerFragment
+import com.bookiibookii.bookiibookii.tracker.nav.TrackerDestinations
 
 private enum class NavTab { HOME, TRACKER, LIBRARY }
 
@@ -114,13 +118,44 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         handleNavigationIntent(intent)
     }
 
+    // 알림(FCM 포그라운드/백그라운드, 인앱) 클릭 → 화면 이동.
+    // FCM data 또는 OS 가 주입한 extra를 라우터가 한 번에 파싱한다.
     private fun handleNavigationIntent(intent: Intent?) {
-        when (intent?.getStringExtra("NAV_ACTION")) {
-            "OPEN_GROUP" -> {
-                moveToGroupTab()
-                intent.removeExtra("NAV_ACTION")
+        val redirect = NotificationRedirectRouter.fromIntent(intent) ?: return
+        dispatchNotificationRedirect(redirect)
+        // 회전·onNewIntent 재설정 시 중복 처리 방지
+        intent?.removeExtra(NotificationRedirectRouter.KEY_REDIRECT_TYPE)
+    }
+
+    // redirectType(백엔드 RedirectType) → 목적지. groupId 없으면 해당 분기는 무시.
+    fun dispatchNotificationRedirect(redirect: NotificationRedirect) {
+        val groupId = redirect.groupId
+        when (redirect.redirectType) {
+            "EXPLORE_HOME" -> selectTab(NavTab.HOME, HomeFragment())
+            "TRACKER_HOME" -> selectTab(NavTab.TRACKER, TrackerFragment())
+            "APPLICATION_MANAGEMENT" -> groupId?.let {
+                pushDeepFragment(GroupFragment.newInstance(GroupDestinations.joinRequests(it.toString())))
             }
+            "GROUP_DETAIL" -> groupId?.let {
+                pushDeepFragment(GroupFragment.newInstance(GroupDestinations.detail(it)))
+            }
+            "TRACKER_DETAIL" -> groupId?.let {
+                pushDeepFragment(TrackerFragment.newInstance(TrackerDestinations.detail(it)))
+            }
+            "TRACKER_COMMENT" -> groupId?.let {
+                pushDeepFragment(TrackerFragment.newInstance(TrackerDestinations.comment(it, redirect.title.orEmpty())))
+            }
+            else -> Log.d("FCM", "라우팅 보류 redirectType=${redirect.redirectType}")
         }
+    }
+
+    // 상세류 화면 진입 — 바텀네비 숨기고 백스택에 쌓아 뒤로가기 시 이전 화면 복귀
+    private fun pushDeepFragment(fragment: Fragment) {
+        binding.bottomNav.root.visibility = View.GONE
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragmentContainer, fragment)
+            .addToBackStack(null)
+            .commit()
     }
 
     private fun initBottomNav() {
@@ -142,11 +177,7 @@ class MainActivity : BaseActivity<ActivityMainBinding>() {
         replaceFragment(fragment)
     }
 
-    fun moveToGroupTab() {
-        selectTab(NavTab.HOME, HomeFragment())
-    }
-
-    // 서재 탭으로 이동 (바텀네비 '서재'를 누른 것과 동일)
+    // 서재 탭으로 이동
     fun moveToLibraryTab() {
         selectTab(NavTab.LIBRARY, LibraryFragment())
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/detail/GroupDetailScreen.kt
@@ -58,6 +58,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.common.showCustomToast
 import com.bookiibookii.bookiibookii.data.model.group.GroupDetailResponse
+import com.bookiibookii.bookiibookii.error.ErrorActivity
+import com.bookiibookii.bookiibookii.error.model.ErrorType
 import com.bookiibookii.bookiibookii.data.model.group.GroupRule
 import com.bookiibookii.bookiibookii.data.model.group.ParticipantSlot
 import com.bookiibookii.bookiibookii.group.model.ExchangeType
@@ -104,6 +106,8 @@ fun GroupDetailRoute(
         viewModel.eventFlow.collect { event ->
             when (event) {
                 is GroupDetailViewModel.Event.Deleted -> onDeleted()
+                is GroupDetailViewModel.Event.NotFound ->
+                    context.startActivity(ErrorActivity.newIntent(context, ErrorType.GROUP_DELETED))
                 is GroupDetailViewModel.Event.ShowError ->
                     context.showCustomToast(event.message, isSuccess = false)
             }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/joinrequest/GroupJoinRequestScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/joinrequest/GroupJoinRequestScreen.kt
@@ -34,6 +34,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.common.showCustomToast
 import com.bookiibookii.bookiibookii.data.model.group.GroupAppItem
+import com.bookiibookii.bookiibookii.error.ErrorActivity
+import com.bookiibookii.bookiibookii.error.model.ErrorType
 import com.bookiibookii.bookiibookii.group.model.ApplicationListUiState
 import com.bookiibookii.bookiibookii.group.vm.JoinRequestViewModel
 import com.bookiibookii.bookiibookii.ui.component.BookCover
@@ -74,6 +76,8 @@ fun GroupJoinRequestRoute(
                 }
                 is JoinRequestViewModel.Event.ShowError ->
                     context.showCustomToast(event.message, isSuccess = false)
+                is JoinRequestViewModel.Event.NotFound ->
+                    context.startActivity(ErrorActivity.newIntent(context, ErrorType.GROUP_DELETED))
                 is JoinRequestViewModel.Event.Applied,
                 is JoinRequestViewModel.Event.Canceled,
                 is JoinRequestViewModel.Event.AddressReady,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupDetailViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/GroupDetailViewModel.kt
@@ -29,6 +29,7 @@ class GroupDetailViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
 
     sealed class Event {
         data object Deleted : Event()
+        data object NotFound : Event()
         data class ShowError(val message: String) : Event()
     }
 
@@ -58,6 +59,10 @@ class GroupDetailViewModel(savedStateHandle: SavedStateHandle) : ViewModel() {
                             error = null,
                         )
                     }
+                } else if (res.code() == 404) {
+                    // 삭제된/존재하지 않는 그룹(예: 예전 알림으로 진입) → 삭제된 페이지 안내
+                    _eventFlow.emit(Event.NotFound)
+                    _state.update { it.copy(loading = false) }
                 } else {
                     _state.update { it.copy(error = "그룹 정보를 불러오지 못했어요", loading = false) }
                 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/JoinRequestViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/vm/JoinRequestViewModel.kt
@@ -58,6 +58,8 @@ class JoinRequestViewModel : ViewModel() {
         // status: "ACCEPTED" | "REJECTED"
         data class ApplicationUpdated(val status: String, val applicantName: String) : Event()
         data class ShowError(val message: String) : Event()
+        // 삭제된/존재하지 않는 그룹 → 삭제된 페이지 화면
+        data object NotFound : Event()
         // APPLY 전 주소 등록 여부 확인 결과
         data object AddressReady : Event()    // 주소 있음 → 참여 신청 다이얼로그
         data object AddressMissing : Event()  // 주소 없음 → 주소 등록 안내 다이얼로그
@@ -225,6 +227,10 @@ class JoinRequestViewModel : ViewModel() {
                             error = null,
                         )
                     }
+                } else if (res.code() == 404) {
+                    // 삭제된/존재하지 않는 그룹(예: 예전 알림으로 진입) → 삭제된 페이지 안내
+                    _eventFlow.emit(Event.NotFound)
+                    _applicationListState.update { it.copy(loading = false) }
                 } else {
                     _applicationListState.update {
                         it.copy(error = "신청자 명단을 불러오지 못했어요", loading = false)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/mypage/MypageFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/mypage/MypageFragment.kt
@@ -45,5 +45,12 @@ class MypageFragment : Fragment() {
                 putString(ARG_START_DESTINATION, MypageDestinations.addressManagement(initialTab))
             }
         }
+
+        // 알림 클릭 딥링크 진입 (예: 공지 상세)
+        fun newInstance(startDestination: String) = MypageFragment().apply {
+            arguments = Bundle().apply {
+                putString(ARG_START_DESTINATION, startDestination)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/notification/NotificationFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/notification/NotificationFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import com.bookiibookii.bookiibookii.MainActivity
 import com.bookiibookii.bookiibookii.notification.nav.NotificationDestinations
 import com.bookiibookii.bookiibookii.notification.nav.NotificationNavHost
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
@@ -26,6 +27,7 @@ class NotificationFragment : Fragment() {
                 NotificationNavHost(
                     startDestination = startDestination,
                     onExit = { parentFragmentManager.popBackStack() },
+                    onRedirect = { (activity as? MainActivity)?.dispatchNotificationRedirect(it) },
                 )
             }
         }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/notification/fcm/BookiiMessagingService.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/notification/fcm/BookiiMessagingService.kt
@@ -44,9 +44,9 @@ class BookiiMessagingService : FirebaseMessagingService() {
 
     // data 는 클릭 시 화면 이동을 위해 Intent extra(String)로 그대로 싣는다.
     // 백그라운드/종료 상태에서 OS 가 트레이 클릭으로 주입하는 extra 와 같은 형식 →
-    // MainActivity 가 양쪽을 동일하게 라우팅한다.
+    // MainActivity 가 양쪽을 동일하게 라우팅
     private fun showNotification(title: String, body: String, data: Map<String, String>) {
-        // 알림마다 다른 ID — 알림이 덮어쓰지 않고 쌓이며, PendingIntent extra 도 분리된다.
+        // 알림마다 다른 ID — 알림이 덮어쓰지 않고 쌓이며, PendingIntent extra 도 분리
         val notificationId = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
 
         val intent = Intent(this, MainActivity::class.java).apply {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/notification/fcm/BookiiMessagingService.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/notification/fcm/BookiiMessagingService.kt
@@ -39,17 +39,23 @@ class BookiiMessagingService : FirebaseMessagingService() {
         val title = message.notification?.title ?: "부키부키"
         val body = message.notification?.body ?: ""
 
-        showNotification(title, body)
+        showNotification(title, body, message.data)
     }
 
-    private fun showNotification(title: String, body: String) {
-        // 탭 시 앱(MainActivity) 열기. 화면별 라우팅 분기는 백엔드 data 스펙 확정 후 추가.
+    // data 는 클릭 시 화면 이동을 위해 Intent extra(String)로 그대로 싣는다.
+    // 백그라운드/종료 상태에서 OS 가 트레이 클릭으로 주입하는 extra 와 같은 형식 →
+    // MainActivity 가 양쪽을 동일하게 라우팅한다.
+    private fun showNotification(title: String, body: String, data: Map<String, String>) {
+        // 알림마다 다른 ID — 알림이 덮어쓰지 않고 쌓이며, PendingIntent extra 도 분리된다.
+        val notificationId = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
+
         val intent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            data.forEach { (key, value) -> putExtra(key, value) }
         }
         val pendingIntent = PendingIntent.getActivity(
             this,
-            0,
+            notificationId,
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
@@ -73,8 +79,6 @@ class BookiiMessagingService : FirebaseMessagingService() {
             return
         }
 
-        // 여러 알림이 덮어쓰지 않고 쌓이도록 매번 다른 ID 사용
-        val notificationId = (System.currentTimeMillis() % Int.MAX_VALUE).toInt()
         NotificationManagerCompat.from(this).notify(notificationId, notification)
     }
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/notification/nav/NotificationNavHost.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/notification/nav/NotificationNavHost.kt
@@ -13,6 +13,7 @@ import com.bookiibookii.bookiibookii.notification.ui.NotificationRoute
 @Composable
 fun NotificationNavHost(
     onExit: () -> Unit,
+    onRedirect: (NotificationRedirect) -> Unit,
     modifier: Modifier = Modifier,
     startDestination: String = NotificationDestinations.MAIN,
 ) {
@@ -31,6 +32,7 @@ fun NotificationNavHost(
             NotificationRoute(
                 onBackClick = { if (!navController.popBackStack()) onExit() },
                 onAddClick = { navController.navigate(NotificationDestinations.KEYWORD_SETTING) },
+                onRedirect = onRedirect,
             )
         }
         composable(NotificationDestinations.KEYWORD_SETTING) {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/notification/nav/NotificationRedirectRouter.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/notification/nav/NotificationRedirectRouter.kt
@@ -1,0 +1,57 @@
+package com.bookiibookii.bookiibookii.notification.nav
+
+import android.content.Intent
+
+// 백엔드 RedirectType enum(8종) 기준이며, 모든 라우팅은 groupId 로 식별.
+data class NotificationRedirect(
+    val redirectType: String,
+    val groupId: Long? = null,
+    val cardId: Long? = null,
+    val title: String? = null,
+)
+
+/**
+ * 알림 라우팅 정보를 추출하는 공용 라우터.
+ *
+ * 같은 키 체계(redirectType/groupId/...)를 세 경로에서 공유한다:
+ * - FCM 포그라운드: BookiiMessagingService 가 message.data 를 그대로 Intent extra(String)로 실어줌
+ * - FCM 백그라운드/종료: OS 가 트레이 클릭 시 data 를 String extra 로 자동 주입 (위와 동일 키)
+ * - 인앱 알림: NotificationItem.payload
+ *
+ * String/Number 를 모두 Long 으로 변환
+ */
+object NotificationRedirectRouter {
+
+    const val KEY_REDIRECT_TYPE = "redirectType"
+    const val KEY_GROUP_ID = "groupId"
+    const val KEY_CARD_ID = "cardId"
+    const val KEY_TITLE = "title"
+
+    private val KEYS = listOf(KEY_REDIRECT_TYPE, KEY_GROUP_ID, KEY_CARD_ID, KEY_TITLE)
+
+    // 인앱 알림 payload (Map) 용
+    fun fromPayload(data: Map<String, *>?): NotificationRedirect? {
+        val redirectType = data?.get(KEY_REDIRECT_TYPE)
+            ?.toString()?.takeIf { it.isNotBlank() } ?: return null
+        return NotificationRedirect(
+            redirectType = redirectType,
+            groupId = asLong(data[KEY_GROUP_ID]),
+            cardId = asLong(data[KEY_CARD_ID]),
+            title = data[KEY_TITLE]?.toString()?.takeIf { it.isNotBlank() },
+        )
+    }
+
+    // FCM 포그라운드/백그라운드 Intent extra (모두 String) 용
+    fun fromIntent(intent: Intent?): NotificationRedirect? {
+        intent ?: return null
+        val data = KEYS.mapNotNull { key -> intent.getStringExtra(key)?.let { key to it } }.toMap()
+        return fromPayload(data)
+    }
+
+    // FCM(String) / 인앱 payload(Number) 둘 다 Long 으로 변환
+    private fun asLong(value: Any?): Long? = when (value) {
+        is Number -> value.toLong()
+        is String -> value.toLongOrNull()
+        else -> null
+    }
+}

--- a/app/src/main/java/com/bookiibookii/bookiibookii/notification/ui/NotificationRoute.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/notification/ui/NotificationRoute.kt
@@ -6,12 +6,15 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.bookiibookii.bookiibookii.notification.model.toUiModel
+import com.bookiibookii.bookiibookii.notification.nav.NotificationRedirect
+import com.bookiibookii.bookiibookii.notification.nav.NotificationRedirectRouter
 import com.bookiibookii.bookiibookii.notification.vm.NotificationCenterViewModel
 
 @Composable
 fun NotificationRoute(
     onBackClick: () -> Unit,
     onAddClick: () -> Unit,
+    onRedirect: (NotificationRedirect) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: NotificationCenterViewModel = viewModel(),
 ) {
@@ -24,7 +27,10 @@ fun NotificationRoute(
         onTabSelect = viewModel::selectTab,
         onNotificationClick = { item ->
             if (item.isUnread) viewModel.markAsRead(item.id)
-            // TODO: 알림 type/payload 기반 화면 이동 (그룹 상세/트래커 등)
+            // 원본 알림(payload 보유)을 찾아 redirectType 기반으로 화면 이동
+            uiState.items.firstOrNull { it.id == item.id }
+                ?.let { NotificationRedirectRouter.fromPayload(it.payload) }
+                ?.let(onRedirect)
         },
         onLoadMore = viewModel::loadNextPage,
         modifier = modifier,

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/LoginIntroActivity.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/LoginIntroActivity.kt
@@ -25,6 +25,8 @@ class LoginIntroActivity : AppCompatActivity() {
                     flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
                             Intent.FLAG_ACTIVITY_NEW_TASK or
                             Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    // MainActivity가 FCM 알림 라우팅할 수 있도록 전달
+                    intent?.extras?.let { putExtras(it) }
                 }
             )
             finish()

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/TrackerFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/TrackerFragment.kt
@@ -34,6 +34,8 @@ class TrackerFragment : Fragment() {
             BookiiBookiiTheme {
                 TrackerNavHost(
                     startDestination = startDestination,
+                    // 딥링크 진입 시 백버튼이 팝할 게 없으면 트래커 Fragment를 닫음
+                    onExit = { parentFragmentManager.popBackStack() },
                     // "서재로 이동" → 바텀네비 서재 탭을 누른 것처럼 전환
                     onNavigateLibrary = {
                         (activity as? MainActivity)?.moveToLibraryTab()

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/TrackerFragment.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/TrackerFragment.kt
@@ -14,10 +14,16 @@ import com.bookiibookii.bookiibookii.group.nav.GroupDestinations
 import com.bookiibookii.bookiibookii.library.feat.LibraryFragment
 import com.bookiibookii.bookiibookii.mypage.MypageFragment
 import com.bookiibookii.bookiibookii.notification.NotificationFragment
+import com.bookiibookii.bookiibookii.tracker.nav.TrackerDestinations
 import com.bookiibookii.bookiibookii.tracker.nav.TrackerNavHost
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 
 class TrackerFragment : Fragment() {
+
+    // 알림 클릭 등 딥링크 진입 시작점. 없으면 트래커 홈(MAIN).
+    private val startDestination: String
+        get() = arguments?.getString(ARG_START_DESTINATION) ?: TrackerDestinations.MAIN
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -27,6 +33,7 @@ class TrackerFragment : Fragment() {
         setContent {
             BookiiBookiiTheme {
                 TrackerNavHost(
+                    startDestination = startDestination,
                     // "서재로 이동" → 바텀네비 서재 탭을 누른 것처럼 전환
                     onNavigateLibrary = {
                         (activity as? MainActivity)?.moveToLibraryTab()
@@ -78,6 +85,17 @@ class TrackerFragment : Fragment() {
                             .commit()
                     },
                 )
+            }
+        }
+    }
+
+    companion object {
+        private const val ARG_START_DESTINATION = "arg_start_destination"
+
+        // 알림 클릭 딥링크 진입 (예: 트래커 상세/댓글)
+        fun newInstance(startDestination: String) = TrackerFragment().apply {
+            arguments = Bundle().apply {
+                putString(ARG_START_DESTINATION, startDestination)
             }
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/model/TrackerDetailUiState.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/model/TrackerDetailUiState.kt
@@ -38,4 +38,6 @@ data class TrackerDetailUiState(
     val steps: List<TrackerStep> = emptyList(),
     val loading: Boolean = false,
     val error: String? = null,
+    // 삭제된/존재하지 않는 그룹(404) → 삭제된 페이지 화면
+    val notFound: Boolean = false,
 )

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/nav/TrackerNavHost.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/nav/TrackerNavHost.kt
@@ -35,6 +35,8 @@ fun TrackerNavHost(
     onAlertClick: () -> Unit = {},
     modifier: Modifier = Modifier,
     startDestination: String = TrackerDestinations.MAIN,
+    // 딥링크(알림)로 하위 화면이 시작점이 된 경우, 백버튼이 팝할 게 없으면 트래커 밖으로 나감
+    onExit: () -> Unit = {},
 ) {
     val navController = rememberNavController()
 
@@ -103,7 +105,7 @@ fun TrackerNavHost(
                 .collectAsStateWithLifecycle()
             TrackerDetailRoute(
                 groupId = groupId,
-                onBackClick = { navController.popBackStack() },
+                onBackClick = { if (!navController.popBackStack()) onExit() },
                 onNavigateBookReview = { edit ->
                     navController.navigate(TrackerDestinations.bookReview(groupId, edit))
                 },
@@ -142,7 +144,7 @@ fun TrackerNavHost(
                 ?.getBoolean(TrackerDestinations.BOOK_REVIEW_ARG_EDIT) ?: false
             TrackerBookReviewRoute(
                 groupId = groupId,
-                onBackClick = { navController.popBackStack() },
+                onBackClick = { if (!navController.popBackStack()) onExit() },
                 isEdit = isEdit,
             )
         }
@@ -158,7 +160,7 @@ fun TrackerNavHost(
                 ?.getLong(TrackerDestinations.PARTNER_REVIEW_ARG_GROUP_ID) ?: return@composable
             TrackerPartnerReviewRoute(
                 groupId = groupId,
-                onBackClick = { navController.popBackStack() },
+                onBackClick = { if (!navController.popBackStack()) onExit() },
                 // 등록 완료 시 상세가 아니라 메인까지 되돌아감
                 onSubmitDone = {
                     navController.popBackStack(TrackerDestinations.MAIN, inclusive = false)
@@ -184,12 +186,12 @@ fun TrackerNavHost(
             TrackerCommentRoute(
                 groupId = groupId,
                 title = title,
-                onBackClick = { navController.popBackStack() },
+                onBackClick = { if (!navController.popBackStack()) onExit() },
             )
         }
         composable(TrackerDestinations.PLACE_SEARCH) {
             PlaceSearchScreen(
-                onBackClick = { navController.popBackStack() },
+                onBackClick = { if (!navController.popBackStack()) onExit() },
                 onPlaceClick = { result ->
                     // 선택 결과를 이전 화면(약속 다이얼로그)으로 반환하고 복귀
                     navController.previousBackStackEntry

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/comment/TrackerCommentScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/comment/TrackerCommentScreen.kt
@@ -78,6 +78,8 @@ import com.bookiibookii.bookiibookii.common.DateUtils
 import com.bookiibookii.bookiibookii.common.showCustomToast
 import com.bookiibookii.bookiibookii.data.model.group.CommentItem
 import com.bookiibookii.bookiibookii.data.model.group.CommentWriter
+import com.bookiibookii.bookiibookii.error.ErrorActivity
+import com.bookiibookii.bookiibookii.error.model.ErrorType
 import com.bookiibookii.bookiibookii.onboarding.login.TokenManager
 import com.bookiibookii.bookiibookii.tracker.vm.TrackerCommentViewModel
 import com.bookiibookii.bookiibookii.ui.component.BookiiBackButton
@@ -114,6 +116,8 @@ fun TrackerCommentRoute(
                 is TrackerCommentViewModel.Event.ShowError -> {
                     context.showCustomToast(event.message, isSuccess = false)
                 }
+                is TrackerCommentViewModel.Event.NotFound ->
+                    context.startActivity(ErrorActivity.newIntent(context, ErrorType.GROUP_DELETED))
             }
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDetailScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/ui/detail/TrackerDetailScreen.kt
@@ -18,6 +18,8 @@ import com.bookiibookii.bookiibookii.R
 import com.bookiibookii.bookiibookii.common.openExternalUrl
 import com.bookiibookii.bookiibookii.common.openReportChannel
 import com.bookiibookii.bookiibookii.common.showCustomToast
+import com.bookiibookii.bookiibookii.error.ErrorActivity
+import com.bookiibookii.bookiibookii.error.model.ErrorType
 import com.bookiibookii.bookiibookii.tracker.ui.detail.delivery.deliveryTrackingUrl
 import com.bookiibookii.bookiibookii.data.model.location.PlaceSearchResult
 import com.bookiibookii.bookiibookii.data.model.tracker.MeetingPlace
@@ -71,6 +73,13 @@ fun TrackerDetailRoute(
     val partnerDelivery by viewModel.partnerDelivery.collectAsStateWithLifecycle()
     val meetingPlace by viewModel.meetingPlace.collectAsStateWithLifecycle()
     val meetingInfo by viewModel.meetingInfo.collectAsStateWithLifecycle()
+
+    // 삭제된/존재하지 않는 그룹(404) → 삭제된 페이지 화면
+    LaunchedEffect(uiState.notFound) {
+        if (uiState.notFound) {
+            context.startActivity(ErrorActivity.newIntent(context, ErrorType.GROUP_DELETED))
+        }
+    }
 
     // 최초 진입은 VM init에서 이미 로드하므로 첫 ON_RESUME은 건너뛰고,
     // 하위 화면(서재/리뷰 등)에서 복귀할 때만 상세를 재조회한다. (rememberSaveable로 백스택 복귀 시에도 유지)

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/vm/TrackerCommentViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/vm/TrackerCommentViewModel.kt
@@ -33,6 +33,8 @@ class TrackerCommentViewModel(
     // 일회성 이벤트 — 토스트용
     sealed class Event {
         data class ShowError(val message: String) : Event()
+        // 삭제된/존재하지 않는 그룹(404) → 삭제된 페이지 화면
+        data object NotFound : Event()
     }
 
     init {
@@ -49,6 +51,10 @@ class TrackerCommentViewModel(
                 val list = res.body()?.result
                 if (res.isSuccessful && res.body()?.isSuccess == true && list != null) {
                     _state.update { it.copy(comments = list, loading = false, error = null) }
+                } else if (res.code() == 404) {
+                    // 삭제된/존재하지 않는 그룹(예: 예전 알림으로 진입) → 삭제된 페이지 안내
+                    _eventFlow.emit(Event.NotFound)
+                    _state.update { it.copy(loading = false) }
                 } else {
                     _state.update { it.copy(error = "댓글을 불러오지 못했어요", loading = false) }
                 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/tracker/vm/TrackerDetailViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/tracker/vm/TrackerDetailViewModel.kt
@@ -371,6 +371,9 @@ class TrackerDetailViewModel(
                     } else {
                         _state.update { it.copy(error = "트래커를 불러오지 못했어요", loading = false) }
                     }
+                } else if (res.code() == 404) {
+                    // 삭제된/존재하지 않는 그룹(예: 예전 알림으로 진입) → 삭제된 페이지 안내
+                    _state.update { it.copy(notFound = true, loading = false) }
                 } else {
                     _state.update { it.copy(error = body?.message ?: "트래커를 불러오지 못했어요", loading = false) }
                 }


### PR DESCRIPTION
# 📌 Pull Request Title
> - feat: FCM·인앱 알림 클릭 화면 이동 구현

---

# ✨ 작업 내용 (What)
> - 알림 공용 라우터 NotificationRedirectRouter 추가 
> - 삭제된 페이지 에러 화면 연결 추가
> - redirectType 목적지 매핑     
    - APPLICATION_MANAGEMENT → 그룹 신청자관리                                                                                                                                                                                           
    - GROUP_DETAIL → 그룹 상세                                                                                                                                                                                                           
    - EXPLORE_HOME → 홈 탭                                                                                                                                                                                                               
    - TRACKER_HOME → 트래커 홈                                                                                                                                                                                                           
    - TRACKER_DETAIL → 트래커 상세                                                                                                                                                                                                       
    - TRACKER_COMMENT → 트래커 댓글

---

# 💡추가 사항
> - 삭제된 페이지 에러 화면 추가 확인 필요
> - 독서카드 진입점 미연결

---

# 🔗 관련 이슈 (Optional)
- close #417
