### PR TITLE
스플래쉬,온보딩 4차 QA 반영

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/ui/IntroScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/ui/IntroScreen.kt
@@ -1,6 +1,7 @@
 package com.bookiibookii.bookiibookii.onboarding.Intro.ui
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
@@ -17,13 +18,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -43,51 +43,52 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.bookiibookii.bookiibookii.ui.theme.BookiiBookiiTheme
 import kotlinx.coroutines.delay
 
+// 페이지: 0=로고, 1=슬로건, 2=홈, 3=트래커, 4=서재, 5=후기+시작
 private const val PAGE_COUNT = 6
 
-@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 0 – 로고")
+@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 1 – 로고")
 @Composable
 private fun PreviewPage0() { BookiiBookiiTheme { IntroScreen(onStart = {}, initialPage = 0) } }
 
-@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 1 – 슬로건")
+@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 2 – 슬로건")
 @Composable
 private fun PreviewPage1() { BookiiBookiiTheme { IntroScreen(onStart = {}, initialPage = 1) } }
 
-@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 2 – 홈")
+@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 3 – 홈")
 @Composable
 private fun PreviewPage2() { BookiiBookiiTheme { IntroScreen(onStart = {}, initialPage = 2) } }
 
-@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 3 – 트래커")
+@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 4 – 트래커")
 @Composable
 private fun PreviewPage3() { BookiiBookiiTheme { IntroScreen(onStart = {}, initialPage = 3) } }
 
-@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 4 – 서재")
+@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 5 – 서재")
 @Composable
 private fun PreviewPage4() { BookiiBookiiTheme { IntroScreen(onStart = {}, initialPage = 4) } }
 
-@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 5 – 시작")
+@Preview(showBackground = true, widthDp = 390, heightDp = 844, name = "Page 6 – 시작")
 @Composable
 private fun PreviewPage5() { BookiiBookiiTheme { IntroScreen(onStart = {}, initialPage = 5) } }
 
 @Composable
 fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
-    val pagerState = rememberPagerState(initialPage = initialPage, pageCount = { PAGE_COUNT })
+    var currentPage by remember { mutableIntStateOf(initialPage) }
     var startVisible by remember { mutableStateOf(initialPage == PAGE_COUNT - 1) }
-    // 자동 재생이 끝난 뒤부터 사용자가 직접 스와이프해 이전 화면을 다시 볼 수 있게 허용
-    var userScrollEnabled by remember { mutableStateOf(initialPage != 0) }
 
     LaunchedEffect(Unit) {
         if (initialPage != 0) return@LaunchedEffect
-        repeat(PAGE_COUNT - 1) { index ->
-            delay(2500L)
-            pagerState.animateScrollToPage(
-                page = index + 1,
-                animationSpec = tween(durationMillis = 500),
-            )
+        // Page 1: 로고 (2500ms)
+        delay(2500L)
+        // Page 2: 슬로건 (2000ms)
+        currentPage = 1
+        delay(2000L)
+        // Page 3~6: 프리뷰 카드 (2500ms 간격)
+        for (page in 2 until PAGE_COUNT) {
+            currentPage = page
+            if (page < PAGE_COUNT - 1) delay(2500L)
         }
         delay(350L)
         startVisible = true
-        userScrollEnabled = true
     }
 
     Box(
@@ -95,17 +96,16 @@ fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
             .fillMaxSize()
             .background(BookiiBookiiTheme.colors.uiBg),
     ) {
-        // ── Pager: 페이지별 고유 콘텐츠만 (로고·푸터는 바깥 오버레이) ──────────
-        HorizontalPager(
-            state = pagerState,
+        // ── Crossfade: 페이드 인/아웃 전환 ───────────────────────────────────────
+        Crossfade(
+            targetState = currentPage,
+            animationSpec = tween(durationMillis = 500),
+            label = "introPageFade",
             modifier = Modifier.fillMaxSize(),
-            userScrollEnabled = userScrollEnabled,
         ) { page ->
-            Box(
-                modifier = Modifier.fillMaxSize(),
-            ) {
+            Box(modifier = Modifier.fillMaxSize()) {
                 when (page) {
-                    // 스플래시-1: 로고 정중앙 (300dp — Figma 기준)
+                    // Page 1: 로고 정중앙
                     0 -> Image(
                         painter = painterResource(R.drawable.ic_logo_wordmark),
                         contentDescription = null,
@@ -115,7 +115,8 @@ fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
                             .width(300.dp),
                     )
 
-                    // 스플래시-2: 텍스트만 중앙 (로고는 오버레이)
+                    // Page 2: 슬로건 — Figma 1050-57852
+                    // "읽고, 교환하고, 기록해요." (medium) + "부키부키" (bold), 화면 중앙
                     1 -> Column(
                         modifier = Modifier.align(Alignment.Center),
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -135,18 +136,17 @@ fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
                         )
                     }
 
-                    // 스플래시-3~6: 텍스트 + 카드 (로고·푸터는 오버레이)
+                    // Page 3~6: 텍스트 + 프리뷰 카드 — 로고·푸터는 오버레이
                     else -> {
-                        // 페이지 텍스트
                         Text(
                             text = when (page) {
                                 2 -> "오늘은 누구와\n어떤 책으로 만나볼까요?"
                                 3 -> "책을 교환하는 모든 순간을\n단계별로 관리해요."
-                                4 -> "서로의 문장을 공유하며\n넓어지는 둘만의 서재"
+                                4 -> "서로의 문장을 공유하며\n넓어지는 우리만의 서재"
                                 else -> "지금 부키부키에서\n나와 꼭 맞는 독서 파트너를 찾아보세요!"
                             },
                             style = BookiiBookiiTheme.typography.semibold20,
-                            color = BookiiBookiiTheme.colors.uiMain,
+                            color = BookiiBookiiTheme.colors.grey900,
                             textAlign = TextAlign.Center,
                             modifier = Modifier
                                 .align(Alignment.TopCenter)
@@ -154,7 +154,6 @@ fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
                                 .padding(top = 121.dp),
                         )
 
-                        // 프리뷰 카드 (화면 하단에서 피킹)
                         Box(
                             modifier = Modifier
                                 .align(Alignment.TopCenter)
@@ -173,8 +172,8 @@ fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
             }
         }
 
-        // ── 오버레이: 상단 로고 (페이지 1~5 고정 — 슬라이드 시 움직이지 않음) ──
-        if (pagerState.currentPage >= 1) {
+        // ── 오버레이: 상단 로고 (Page 2~6 고정) ──────────────────────────────────
+        if (currentPage >= 1) {
             Image(
                 painter = painterResource(R.drawable.ic_logo_wordmark),
                 contentDescription = null,
@@ -187,8 +186,8 @@ fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
             )
         }
 
-        // ── 오버레이: 하단 푸터 104dp (페이지 2~5 고정 — 카드 하단 가림) ────────
-        if (pagerState.currentPage >= 2) {
+        // ── 오버레이: 하단 푸터 104dp (Page 3~6) ─────────────────────────────────
+        if (currentPage >= 2) {
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
@@ -197,8 +196,8 @@ fun IntroScreen(onStart: () -> Unit, initialPage: Int = 0) {
                     .background(BookiiBookiiTheme.colors.uiBg),
                 contentAlignment = Alignment.Center,
             ) {
-                // 마지막 페이지: 시작 버튼
-                if (pagerState.currentPage == PAGE_COUNT - 1) {
+                // Page 6: 시작 버튼
+                if (currentPage == PAGE_COUNT - 1) {
                     AnimatedVisibility(
                         visible = startVisible,
                         enter = fadeIn() + slideInVertically(initialOffsetY = { it / 4 }),

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/ui/component/IntroPreviewCards.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/ui/component/IntroPreviewCards.kt
@@ -237,18 +237,18 @@ fun TrackerPreviewCard() {
             Row {
                 Text(
                     text = "sayo",
-                    style = BookiiBookiiTheme.typography.regular18,
+                    style = BookiiBookiiTheme.typography.regular20,
                     color = BookiiBookiiTheme.colors.uiMain,
                 )
                 Text(
                     text = "님의",
-                    style = BookiiBookiiTheme.typography.regular18,
+                    style = BookiiBookiiTheme.typography.regular20,
                     color = BookiiBookiiTheme.colors.grey900,
                 )
             }
             Text(
                 text = "교환독서 현황을 알려드려요",
-                style = BookiiBookiiTheme.typography.regular18,
+                style = BookiiBookiiTheme.typography.regular20,
                 color = BookiiBookiiTheme.colors.grey900,
             )
         }
@@ -336,7 +336,7 @@ fun TrackerPreviewCard() {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(300.dp)
+                    .height(360.dp)
                     .clip(RoundedCornerShape(14.dp))
                     .background(BookiiBookiiTheme.colors.white)
                     .padding(12.dp),

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/ui/component/IntroPreviewCards.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/Intro/ui/component/IntroPreviewCards.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -26,11 +27,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -55,8 +59,8 @@ private fun PreviewCardWrapper(content: @Composable () -> Unit) {
                 ambientColor = Color(0x1A000000),
                 spotColor = Color(0x1A000000),
             )
-            .clip(RoundedCornerShape(20.dp))
             .border(1.5.dp, BookiiBookiiTheme.colors.grey200, RoundedCornerShape(20.dp))
+            .clip(RoundedCornerShape(20.dp))
             .background(BookiiBookiiTheme.colors.uiBg),
     ) {
         content()
@@ -122,10 +126,10 @@ fun HomePreviewCard() {
                         bookRes = R.drawable.intro_book_boy,
                         profileRes = R.drawable.intro_profile_mus,
                         bookTitle = "소년이 온다",
-                        bookAuthor = "한강 (소설)",
-                        readingDays = "14일",
+                        bookAuthor = "한강 (한국소설)",
+                        readingDays = "7일",
                         username = "무스",
-                        comment = "같이 읽을 분 환영해요",
+                        comment = "함께 완독해요",
                     )
                 }
             }
@@ -217,43 +221,47 @@ private fun TrackerPreviewCardPreview() {
 
 @Composable
 fun TrackerPreviewCard() {
+    val grey100 = BookiiBookiiTheme.colors.grey100
     PreviewCardWrapper {
-        // 알림 보드
+        // 알림 보드 (Figma: border-b only, pt=16dp pb=12dp)
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(BookiiBookiiTheme.colors.white)
-                .border(
-                    width = 0.5.dp,
-                    color = BookiiBookiiTheme.colors.grey100,
-                    shape = RoundedCornerShape(topStart = 0.dp, topEnd = 0.dp, bottomStart = 0.dp, bottomEnd = 0.dp),
-                )
-                .padding(horizontal = 12.dp, vertical = 12.dp),
+                .drawBehind {
+                    val sw = 0.5.dp.toPx()
+                    drawLine(grey100, Offset(0f, size.height - sw / 2), Offset(size.width, size.height - sw / 2), sw)
+                }
+                .padding(start = 12.dp, end = 12.dp, top = 16.dp, bottom = 12.dp),
         ) {
             Row {
                 Text(
                     text = "sayo",
-                    style = BookiiBookiiTheme.typography.regular14,
+                    style = BookiiBookiiTheme.typography.regular18,
                     color = BookiiBookiiTheme.colors.uiMain,
                 )
                 Text(
                     text = "님의",
-                    style = BookiiBookiiTheme.typography.regular14,
+                    style = BookiiBookiiTheme.typography.regular18,
                     color = BookiiBookiiTheme.colors.grey900,
                 )
             }
             Text(
                 text = "교환독서 현황을 알려드려요",
-                style = BookiiBookiiTheme.typography.regular14,
+                style = BookiiBookiiTheme.typography.regular18,
                 color = BookiiBookiiTheme.colors.grey900,
             )
         }
 
-        // 알림 카드
+        // 알림 카드 (Figma: border-t only)
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(BookiiBookiiTheme.colors.white)
+                .drawBehind {
+                    val sw = 0.5.dp.toPx()
+                    drawLine(grey100, Offset(0f, sw / 2), Offset(size.width, sw / 2), sw)
+                }
                 .padding(horizontal = 17.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(3.dp),
         ) {
@@ -281,12 +289,12 @@ fun TrackerPreviewCard() {
             Row {
                 Text(
                     text = "살인자의 기억법",
-                    style = BookiiBookiiTheme.typography.regular11,
+                    style = BookiiBookiiTheme.typography.regular10,
                     color = BookiiBookiiTheme.colors.grey900,
                 )
                 Text(
                     text = "을 읽고 후기를 작성해주세요",
-                    style = BookiiBookiiTheme.typography.regular11,
+                    style = BookiiBookiiTheme.typography.regular10,
                     color = BookiiBookiiTheme.colors.grey700,
                 )
             }
@@ -328,14 +336,21 @@ fun TrackerPreviewCard() {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .height(300.dp)
                     .clip(RoundedCornerShape(14.dp))
                     .background(BookiiBookiiTheme.colors.white)
                     .padding(12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                // 헤더
+                // 헤더 (Figma: border-b 구분선)
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .drawBehind {
+                            val sw = 0.5.dp.toPx()
+                            drawLine(grey100, Offset(0f, size.height - sw / 2), Offset(size.width, size.height - sw / 2), sw)
+                        }
+                        .padding(bottom = 6.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.Top,
                 ) {
@@ -387,8 +402,10 @@ fun TrackerPreviewCard() {
                         name = "나",
                         bookTitle = "살인자의 기억법",
                         bookCoverRes = R.drawable.intro_book_killer,
+                        profileRes = R.drawable.intro_profile_sayo_tracker,
                         progress = 0.59f,
                         progressText = "59%",
+                        progressColor = BookiiBookiiTheme.colors.grey400,
                         showMyBookChip = true,
                     )
                     TrackerPersonColumn(
@@ -396,8 +413,10 @@ fun TrackerPreviewCard() {
                         name = "noshel",
                         bookTitle = "작별인사",
                         bookCoverRes = R.drawable.intro_book_farewell,
+                        profileRes = R.drawable.intro_profile_noshel,
                         progress = 0.30f,
                         progressText = "30%",
+                        progressColor = BookiiBookiiTheme.colors.grey400,
                         showMyBookChip = false,
                     )
                 }
@@ -495,11 +514,21 @@ fun LibraryPreviewCard() {
                         color = BookiiBookiiTheme.colors.grey900,
                     )
                     // 별점 (4.5/5)
-                    Row {
+                    Row(horizontalArrangement = Arrangement.spacedBy(1.dp)) {
                         repeat(4) {
-                            Text(text = "★", style = BookiiBookiiTheme.typography.regular12, color = BookiiBookiiTheme.colors.uiMain)
+                            Image(
+                                painter = painterResource(R.drawable.ic_star_fill),
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.uiMain),
+                                modifier = Modifier.size(12.dp),
+                            )
                         }
-                        Text(text = "☆", style = BookiiBookiiTheme.typography.regular12, color = BookiiBookiiTheme.colors.grey300)
+                        Image(
+                            painter = painterResource(R.drawable.ic_star),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey300),
+                            modifier = Modifier.size(12.dp),
+                        )
                     }
                     Text(
                         text = "2026. 05. 09. ~ 2026. 05. 31.",
@@ -555,6 +584,7 @@ fun LibraryPreviewCard() {
                     modifier = Modifier.weight(1f),
                     profileRes = R.drawable.intro_profile_noshel_lib2,
                     name = "noshel",
+                    bodyText = "좋은 사람이 결국 행복해지는 이야기를 어떻게 사랑하지 않을 수 있겠어...",
                     quote = "\"너랑 나는 좋은 사람.\" 로키가 말한다. \"그러게.\" 나는 미소 짓는다. \"그런 것 같아.\"",
                     page = "p.506",
                 )
@@ -578,7 +608,7 @@ fun LibraryPreviewCard() {
                     modifier = Modifier.weight(1f),
                     profileRes = R.drawable.intro_profile_sayo_lib4,
                     name = "sayo",
-                    text = "나 행복. 너 안 죽음. 행성들을 구하자! 아름다워...",
+                    text = "나 행복. 너 안 죽음. 행성들을 구하자! 아름다워...ㅜㅜ",
                     page = "p.97",
                     photoRes = R.drawable.intro_reading_card_photo4,
                 )
@@ -587,8 +617,10 @@ fun LibraryPreviewCard() {
                     modifier = Modifier.weight(1f),
                     profileRes = R.drawable.intro_profile_noshel_lib3,
                     name = "noshel",
+                    bodyText = "말 한마디 없이 아프다는 걸 알아채는 거, 이게 진짜 우정이지 않을까?",
                     quote = "\"인간은 슬프면 눈에서 물이 흘러나와.\" \"알았다. 나는 네가 물이 새지 않을 때까지 지켜본다.\"",
                     page = "p.97",
+                    showBookmark = false,
                 )
             }
         }
@@ -605,6 +637,7 @@ private fun ReviewPreviewCardPreview() {
 
 @Composable
 fun ReviewPreviewCard() {
+    val grey100 = BookiiBookiiTheme.colors.grey100
     PreviewCardWrapper {
         Column(
             modifier = Modifier.fillMaxWidth().padding(12.dp),
@@ -619,30 +652,27 @@ fun ReviewPreviewCard() {
                     .padding(12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                // 헤더
+                // 헤더 (Figma: border-b only)
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = 6.dp),
+                        .drawBehind {
+                            val sw = 0.5.dp.toPx()
+                            drawLine(grey100, Offset(0f, size.height - sw / 2), Offset(size.width, size.height - sw / 2), sw)
+                        }
+                        .padding(bottom = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(3.dp),
                 ) {
-                    Box(
-                        modifier = Modifier.fillMaxWidth().padding(bottom = 6.dp)
-                            .border(0.5.dp, BookiiBookiiTheme.colors.grey100, shape = RoundedCornerShape(0.dp)),
-                    ) {
-                        Column(modifier = Modifier.padding(bottom = 6.dp)) {
-                            Text(
-                                text = "김영하 도장깨기 하실 분",
-                                style = BookiiBookiiTheme.typography.medium12,
-                                color = BookiiBookiiTheme.colors.grey900,
-                            )
-                            Text(
-                                text = "2026. 04. 29. ~ 2026. 05. 17.",
-                                style = BookiiBookiiTheme.typography.regular11,
-                                color = BookiiBookiiTheme.colors.grey500,
-                            )
-                        }
-                    }
+                    Text(
+                        text = "김영하 도장깨기 하실 분",
+                        style = BookiiBookiiTheme.typography.medium12,
+                        color = BookiiBookiiTheme.colors.grey900,
+                    )
+                    Text(
+                        text = "2026. 04. 29. ~ 2026. 05. 17.",
+                        style = BookiiBookiiTheme.typography.regular11,
+                        color = BookiiBookiiTheme.colors.grey500,
+                    )
                 }
 
                 // noshel 버블 (오른쪽)
@@ -670,7 +700,12 @@ fun ReviewPreviewCard() {
                                 .background(BookiiBookiiTheme.colors.uiMainPale),
                             contentAlignment = Alignment.Center,
                         ) {
-                            Text(text = "👍", style = BookiiBookiiTheme.typography.regular10, color = BookiiBookiiTheme.colors.uiMain)
+                            Image(
+                                painter = painterResource(R.drawable.ic_hand_thumbs_up),
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.uiMain),
+                                modifier = Modifier.size(12.dp),
+                            )
                         }
                         Box(
                             modifier = Modifier
@@ -857,7 +892,11 @@ private fun GroupCard(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            BookCoverImage(imageRes = bookRes, width = 52.dp, height = 73.dp, cornerRadius = 6.dp)
+            Box(
+                modifier = Modifier.border(0.5.dp, BookiiBookiiTheme.colors.grey100, RoundedCornerShape(6.dp)),
+            ) {
+                BookCoverImage(imageRes = bookRes, width = 52.dp, height = 73.dp, cornerRadius = 6.dp)
+            }
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -940,12 +979,13 @@ private fun BookCoverImage(
 private fun ProfileCircleImage(
     @DrawableRes imageRes: Int,
     size: Dp,
+    modifier: Modifier = Modifier,
 ) {
     Image(
         painter = painterResource(imageRes),
         contentDescription = null,
         contentScale = ContentScale.Crop,
-        modifier = Modifier
+        modifier = modifier
             .size(size)
             .clip(CircleShape),
     )
@@ -979,15 +1019,20 @@ private fun BookGridItem(
         horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        Image(
-            painter = painterResource(imageRes),
-            contentDescription = null,
-            contentScale = ContentScale.Crop,
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(87.dp)
+                .aspectRatio(2f / 3f)
+                .border(0.5.dp, BookiiBookiiTheme.colors.grey100, RoundedCornerShape(7.dp))
                 .clip(RoundedCornerShape(7.dp)),
-        )
+        ) {
+            Image(
+                painter = painterResource(imageRes),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
         Text(
             text = title,
             style = BookiiBookiiTheme.typography.regular11,
@@ -1032,80 +1077,107 @@ private fun TrackerPersonColumn(
     name: String,
     bookTitle: String,
     @DrawableRes bookCoverRes: Int,
+    @DrawableRes profileRes: Int,
     progress: Float,
     progressText: String,
+    progressColor: Color,
     showMyBookChip: Boolean,
 ) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        // 책 표지
-        Box(contentAlignment = Alignment.BottomEnd) {
-            BookCoverImage(imageRes = bookCoverRes, width = 73.dp, height = 96.dp, cornerRadius = 8.dp)
-            if (showMyBookChip) {
-                Box(
-                    modifier = Modifier
-                        .padding(3.dp)
-                        .clip(RoundedCornerShape(4.dp))
-                        .background(Color(0xBFE2E1DF))
-                        .padding(horizontal = 3.dp, vertical = 1.5.dp),
-                ) {
-                    Text(
-                        text = "내 책",
-                        style = BookiiBookiiTheme.typography.regular10,
-                        color = BookiiBookiiTheme.colors.grey900,
-                    )
-                }
-            }
-        }
-
-        // 이름 + 책 제목
+    // Figma: relative container — profile image is absolutely overlaid
+    Box(modifier = modifier) {
         Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 9.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(3.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            Text(
-                text = name,
-                style = BookiiBookiiTheme.typography.regular11,
-                color = BookiiBookiiTheme.colors.grey700,
-            )
-            Text(
-                text = bookTitle,
-                style = BookiiBookiiTheme.typography.medium12,
-                color = BookiiBookiiTheme.colors.grey800,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center,
-            )
-        }
-
-        // 진행률
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 3.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            // 진행 바
+            // 책 표지 (Figma: border 0.5dp grey100)
             Box(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(3.dp)
-                    .clip(RoundedCornerShape(50.dp))
-                    .background(BookiiBookiiTheme.colors.grey200),
+                    .border(0.5.dp, BookiiBookiiTheme.colors.grey100, RoundedCornerShape(8.dp)),
+                contentAlignment = Alignment.BottomEnd,
+            ) {
+                BookCoverImage(imageRes = bookCoverRes, width = 73.dp, height = 96.dp, cornerRadius = 8.dp)
+                if (showMyBookChip) {
+                    Box(
+                        modifier = Modifier
+                            .padding(3.dp)
+                            .clip(RoundedCornerShape(4.dp))
+                            .background(Color(0xBFE2E1DF))
+                            .padding(horizontal = 3.dp, vertical = 1.5.dp),
+                    ) {
+                        Text(
+                            text = "내 책",
+                            style = BookiiBookiiTheme.typography.regular10,
+                            color = BookiiBookiiTheme.colors.grey900,
+                        )
+                    }
+                }
+            }
+
+            // 이름 + 책 제목
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(3.dp),
+            ) {
+                Text(
+                    text = name,
+                    style = BookiiBookiiTheme.typography.regular11,
+                    color = BookiiBookiiTheme.colors.grey700,
+                )
+                Text(
+                    text = bookTitle,
+                    style = BookiiBookiiTheme.typography.medium12,
+                    color = BookiiBookiiTheme.colors.grey800,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+            }
+
+            // 진행률
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 3.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth(progress)
+                        .fillMaxWidth()
                         .height(3.dp)
                         .clip(RoundedCornerShape(50.dp))
-                        .background(BookiiBookiiTheme.colors.uiMain),
+                        .background(BookiiBookiiTheme.colors.grey200),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(progress)
+                            .height(3.dp)
+                            .clip(RoundedCornerShape(50.dp))
+                            .background(progressColor),
+                    )
+                }
+                Text(
+                    text = progressText,
+                    style = BookiiBookiiTheme.typography.regular11,
+                    color = BookiiBookiiTheme.colors.grey800,
                 )
             }
-            Text(
-                text = progressText,
-                style = BookiiBookiiTheme.typography.regular11,
-                color = BookiiBookiiTheme.colors.grey800,
+        }
+
+        // 프로필 이미지 오버레이 (Figma: absolute position)
+        if (showMyBookChip) {
+            // "나": 컬럼 하단 중앙 (Figma left=60.51dp, top=179.44dp)
+            ProfileCircleImage(
+                imageRes = profileRes,
+                size = 32.dp,
+                modifier = Modifier.offset(x = 60.dp, y = 179.dp),
+            )
+        } else {
+            // 상대방: 컬럼 상단 좌측 (Figma left=12.38dp, top=0dp)
+            ProfileCircleImage(
+                imageRes = profileRes,
+                size = 32.dp,
+                modifier = Modifier.offset(x = 12.dp, y = 0.dp),
             )
         }
     }
@@ -1150,9 +1222,14 @@ private fun ReadingCardText(
                         .clip(CircleShape)
                         .border(0.5.dp, BookiiBookiiTheme.colors.uiMain, CircleShape)
                         .background(BookiiBookiiTheme.colors.uiMainPale)
-                        .padding(1.5.dp),
+                        .padding(3.dp),
                 ) {
-                    Text(text = "🔖", style = BookiiBookiiTheme.typography.regular10)
+                    Image(
+                        painter = painterResource(R.drawable.ic_bookmark_fill),
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.uiMain),
+                        modifier = Modifier.size(10.dp),
+                    )
                 }
             }
             Text(
@@ -1167,7 +1244,12 @@ private fun ReadingCardText(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(text = "♥", style = BookiiBookiiTheme.typography.regular12, color = BookiiBookiiTheme.colors.grey400)
+                Image(
+                    painter = painterResource(R.drawable.ic_heart_fill),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey400),
+                    modifier = Modifier.size(12.dp),
+                )
                 Text(text = page, style = BookiiBookiiTheme.typography.regular11, color = BookiiBookiiTheme.colors.grey400)
             }
         }
@@ -1188,8 +1270,10 @@ private fun ReadingCardQuote(
     modifier: Modifier = Modifier,
     @DrawableRes profileRes: Int,
     name: String,
+    bodyText: String,
     quote: String,
     page: String,
+    showBookmark: Boolean = true,
 ) {
     Column(
         modifier = modifier
@@ -1216,18 +1300,25 @@ private fun ReadingCardQuote(
                     ProfileCircleImage(imageRes = profileRes, size = 17.dp)
                     Text(text = name, style = BookiiBookiiTheme.typography.medium11, color = BookiiBookiiTheme.colors.grey800)
                 }
-                Box(
-                    modifier = Modifier
-                        .clip(CircleShape)
-                        .border(0.5.dp, BookiiBookiiTheme.colors.uiMain, CircleShape)
-                        .background(BookiiBookiiTheme.colors.uiMainPale)
-                        .padding(1.5.dp),
-                ) {
-                    Text(text = "🔖", style = BookiiBookiiTheme.typography.regular10)
+                if (showBookmark) {
+                    Box(
+                        modifier = Modifier
+                            .clip(CircleShape)
+                            .border(0.5.dp, BookiiBookiiTheme.colors.uiMain, CircleShape)
+                            .background(BookiiBookiiTheme.colors.uiMainPale)
+                            .padding(3.dp),
+                    ) {
+                        Image(
+                            painter = painterResource(R.drawable.ic_bookmark_fill),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.uiMain),
+                            modifier = Modifier.size(10.dp),
+                        )
+                    }
                 }
             }
             Text(
-                text = quote.take(40) + "...",
+                text = bodyText,
                 style = BookiiBookiiTheme.typography.regular11,
                 color = BookiiBookiiTheme.colors.grey800,
                 maxLines = 3,
@@ -1238,7 +1329,12 @@ private fun ReadingCardQuote(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(text = "♥", style = BookiiBookiiTheme.typography.regular12, color = BookiiBookiiTheme.colors.grey400)
+                Image(
+                    painter = painterResource(R.drawable.ic_heart_fill),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.grey400),
+                    modifier = Modifier.size(12.dp),
+                )
                 Text(text = page, style = BookiiBookiiTheme.typography.regular11, color = BookiiBookiiTheme.colors.grey400)
             }
         }
@@ -1269,7 +1365,12 @@ private fun ReadingCardQuote(
                     .padding(6.dp),
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                    Text(text = "❝", style = BookiiBookiiTheme.typography.regular12, color = BookiiBookiiTheme.colors.white)
+                    Image(
+                        painter = painterResource(R.drawable.ic_quote),
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(BookiiBookiiTheme.colors.white),
+                        modifier = Modifier.size(12.dp),
+                    )
                     Text(
                         text = quote,
                         style = BookiiBookiiTheme.typography.regular10,
@@ -1285,12 +1386,13 @@ private fun ReadingCardQuote(
 
 @Composable
 private fun StarRow(filledCount: Int) {
-    Row {
+    Row(horizontalArrangement = Arrangement.spacedBy(1.dp)) {
         repeat(5) { i ->
-            Text(
-                text = if (i < filledCount) "★" else "☆",
-                style = BookiiBookiiTheme.typography.regular12,
-                color = if (i < filledCount) BookiiBookiiTheme.colors.uiMain else BookiiBookiiTheme.colors.grey300,
+            Image(
+                painter = painterResource(if (i < filledCount) R.drawable.ic_star_fill else R.drawable.ic_star),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(if (i < filledCount) BookiiBookiiTheme.colors.uiMain else BookiiBookiiTheme.colors.grey300),
+                modifier = Modifier.size(12.dp),
             )
         }
     }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/OnbStepScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/OnbStepScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -144,8 +145,9 @@ private fun OnbStepHeader(onBack: () -> Unit) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(68.dp)
                 .background(colors.white)
+                .statusBarsPadding()
+                .height(68.dp)
                 .padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/content/OnbStep1Content.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/content/OnbStep1Content.kt
@@ -139,7 +139,10 @@ fun OnbStep1Content(
         )
 
         BirthdateSection(
-            birthdateText = state.birthdate?.replace("-", ".") ?: "0000.00.00",
+            birthdateText = state.birthdate?.let {
+                val parts = it.split("-")
+                "${parts[0].takeLast(2)}.${parts[1]}.${parts[2]}."
+            } ?: "00.00.00.",
             isBirthdateSet = state.birthdate != null,
             onClick = { showBirthdateSheet = true }
         )

--- a/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/content/OnbStep1Content.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/onboarding/steps/ui/content/OnbStep1Content.kt
@@ -141,8 +141,8 @@ fun OnbStep1Content(
         BirthdateSection(
             birthdateText = state.birthdate?.let {
                 val parts = it.split("-")
-                "${parts[0].takeLast(2)}.${parts[1]}.${parts[2]}."
-            } ?: "00.00.00.",
+                "${parts[0]}.${parts[1]}.${parts[2]}."
+            } ?: "0000.00.00.",
             isBirthdateSet = state.birthdate != null,
             onClick = { showBirthdateSheet = true }
         )
@@ -480,7 +480,7 @@ private fun GenderSectionSelectedPreview() {
 private fun BirthdateSectionEmptyPreview() {
     BookiiPreview {
         Box(modifier = Modifier.padding(16.dp)) {
-            BirthdateSection(birthdateText = "0000.00.00", isBirthdateSet = false, onClick = {})
+            BirthdateSection(birthdateText = "0000.00.00.", isBirthdateSet = false, onClick = {})
         }
     }
 }
@@ -490,7 +490,7 @@ private fun BirthdateSectionEmptyPreview() {
 private fun BirthdateSectionFilledPreview() {
     BookiiPreview {
         Box(modifier = Modifier.padding(16.dp)) {
-            BirthdateSection(birthdateText = "1997.01.18", isBirthdateSet = true, onClick = {})
+            BirthdateSection(birthdateText = "1997.01.18.", isBirthdateSet = true, onClick = {})
         }
     }
 }

--- a/app/src/main/res/drawable/ic_profile_placeholder.xml
+++ b/app/src/main/res/drawable/ic_profile_placeholder.xml
@@ -26,10 +26,10 @@
             android:fillColor="#FFFFFF"
             android:pathData="M64,32.63C75.046,32.63 84,41.584 84,52.63C84,63.676 75.046,72.63 64,72.63C52.954,72.63 44,63.676 44,52.63C44,41.584 52.954,32.63 64,32.63Z" />
 
-        <!-- Body: Union body path offset by (24, 32.63) into 128 coord space -->
+        <!-- Body: extended to y=150 (beyond viewport) so squircle clip cuts cleanly without anti-alias artifact -->
         <path
             android:fillColor="#FFFFFF"
-            android:pathData="M64.5,79.005C86.868,79.005 105,97.809 105,121.005C105,121.589 104.985,122.171 104.962,122.749C95.403,126.663 82.159,128.005 64,128.005C46.474,128.005 33.527,126.754 24.052,123.149C24.017,122.439 24,121.724 24,121.005C24,97.809 42.133,79.005 64.5,79.005Z" />
+            android:pathData="M64.5,79.005C86.868,79.005 105,97.809 105,121.005L105,150L24,150L24,121.005C24,97.809 42.133,79.005 64.5,79.005Z" />
     </group>
 
 </vector>


### PR DESCRIPTION
# 📌 Pull Request Title
ui: 스플래시, 온보딩 4차 QA 반영 

---

# ✨ 작업 내용 (What)
  **[스플래시 인트로]**                                                                      
  - 페이지 전환 방식 변경: HorizontalPager(좌우 슬라이드) → Crossfade(페이드 인/아웃)        
  - 자동재생 후 스와이프 제거 (자동재생만 동작)                                              
  - 인트로 6페이지 구조 재정비                                                               
    - Page 1: 로고 (2.5초)                                                                   
    - Page 2: 슬로건 "읽고, 교환하고, 기록해요. 부키부키" (2초)
    - Page 3~6: 홈/트래커/서재/후기 프리뷰 카드 (각 2.5초)
  - 각 페이지 프리뷰 카드 피그마 기준으로 구현 및 수정
    - TrackerPreviewCard 알림보드 텍스트 크기 수정
    - TrackerPreviewCard 진행률 바 색상 수정 (주황 → grey400)
    - 페이지 3~6 카드 노출 영역 피그마 기준 맞춤 (하단 푸터에 가려지는 부분)

  **[온보딩 스텝]**
  - OnbStepHeader 상단 statusBarsPadding 추가 (기존 status bar 영역 침범 이슈 수정)
  - Step1 생년월일 표시 형식 변경: `0000.00.00` → `00.00.00.` (연도 뒤 2자리)

  **[기타]**
  - ic_profile_placeholder.xml 하단 body path 수정 (squircle 클리핑 시 안티앨리어싱 아티팩트
  제거)


---

# 🧪 테스트 방법 (How to Test)
  - 앱 실행 → 스플래시 인트로 자동재생 전체 확인 (Page 1~6)
  - 각 페이지 카드 노출 영역이 피그마와 동일한지 확인
  - 온보딩 Step1 진입 → 헤더 영역 status bar 침범 여부 확인
  - 온보딩 Step1 생년월일 선택 후 표시 형식 확인 (`YY.MM.DD.`)


---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!

---

# 🔗 관련 이슈 (Optional)
- close #431

