### PR TITLE
탐색화면 4차 QA 반영

### DIFF
--- a/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/SearchInputField.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/group/ui/search/SearchInputField.kt
@@ -14,9 +14,13 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -44,10 +48,16 @@ fun SearchInputField(
         bottomEnd = 30.dp,
     )
     val focusManager = LocalFocusManager.current
+    val focusRequester = remember { FocusRequester() }
     val submit = {
         focusManager.clearFocus()
         onSearch()
     }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
     Row(
         modifier = modifier
             .clip(shape)
@@ -66,7 +76,9 @@ fun SearchInputField(
             cursorBrush = SolidColor(BookiiBookiiTheme.colors.uiMain),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
             keyboardActions = KeyboardActions(onSearch = { submit() }),
-            modifier = Modifier.weight(1f),
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester),
             decorationBox = { innerTextField ->
                 Box(contentAlignment = Alignment.CenterStart) {
                     if (query.isEmpty()) {

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/HomeViewModel.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/HomeViewModel.kt
@@ -9,6 +9,7 @@ import com.bookiibookii.bookiibookii.data.model.group.GroupItem
 import com.bookiibookii.bookiibookii.data.model.group.HomeSection
 import com.bookiibookii.bookiibookii.onboarding.login.TokenManager
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -50,6 +51,28 @@ class HomeViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
+    // 풀-투-리프레시: 전체 데이터 재로딩 후 isLoading 해제
+    fun refresh() {
+        if (_uiState.value.isLoading) return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                coroutineScope {
+                    launch { loadNickname() }
+                    launch { loadRecommendedGroups() }
+                    launch { loadNotificationDot() }
+                    when (_uiState.value.selectedTab) {
+                        HomeTab.MY_GROUPS -> launch { loadMyGroups() }
+                        HomeTab.APPLIED -> launch { loadAppliedGroups() }
+                        HomeTab.RECOMMEND -> Unit
+                    }
+                }
+            } finally {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        }
+    }
+
     fun selectTab(tab: HomeTab) {
         _uiState.update { it.copy(selectedTab = tab) }
         when (tab) {
@@ -59,31 +82,33 @@ class HomeViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    private fun fetchNickname() {
-        viewModelScope.launch {
-            runCatching {
-                RetrofitClient.mypApi().getMypage()
-            }.onSuccess { response ->
-                val nickname = response.body()?.result?.nickname ?: return@onSuccess
-                _uiState.update { it.copy(nickname = nickname) }
-                TokenManager.saveNickname(getApplication(), nickname)
-            }
+    private fun fetchNickname() = viewModelScope.launch { loadNickname() }
+
+    private suspend fun loadNickname() {
+        runCatching {
+            RetrofitClient.mypApi().getMypage()
+        }.onSuccess { response ->
+            val nickname = response.body()?.result?.nickname ?: return@onSuccess
+            _uiState.update { it.copy(nickname = nickname) }
+            TokenManager.saveNickname(getApplication(), nickname)
         }
     }
 
-    private fun fetchRecommendedGroups() {
-        viewModelScope.launch {
-            runCatching {
-                RetrofitClient.grpApi().getHomeGroups()
-            }.onSuccess { response ->
-                val result = response.body()?.result ?: return@onSuccess
-                _uiState.update { it.copy(recommendSections = result.sections) }
-            }
+    private fun fetchRecommendedGroups() = viewModelScope.launch { loadRecommendedGroups() }
+
+    private suspend fun loadRecommendedGroups() {
+        runCatching {
+            RetrofitClient.grpApi().getHomeGroups()
+        }.onSuccess { response ->
+            val result = response.body()?.result ?: return@onSuccess
+            _uiState.update { it.copy(recommendSections = result.sections) }
         }
     }
 
-    fun fetchNotificationDot() {
-        viewModelScope.launch {
+    fun fetchNotificationDot() = viewModelScope.launch { loadNotificationDot() }
+
+    private suspend fun loadNotificationDot() {
+        coroutineScope {
             val systemDeferred = async {
                 runCatching {
                     RetrofitClient.notiApi().getNotifications("SYSTEM", null, 20)
@@ -99,30 +124,30 @@ class HomeViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    private fun fetchMyGroups() {
-        viewModelScope.launch {
-            runCatching {
-                RetrofitClient.grpApi().getMyHostedGroups()
-            }.onSuccess { response ->
-                val groups = response.body()?.result
-                    ?.filter { it.displayStatus == "BEFORE_MATCHING" } ?: return@onSuccess
-                _uiState.update { it.copy(myGroups = groups) }
-            }
+    private fun fetchMyGroups() = viewModelScope.launch { loadMyGroups() }
+
+    private suspend fun loadMyGroups() {
+        runCatching {
+            RetrofitClient.grpApi().getMyHostedGroups()
+        }.onSuccess { response ->
+            val groups = response.body()?.result
+                ?.filter { it.displayStatus == "BEFORE_MATCHING" } ?: return@onSuccess
+            _uiState.update { it.copy(myGroups = groups) }
         }
     }
 
-    private fun fetchAppliedGroups() {
-        viewModelScope.launch {
-            runCatching {
-                RetrofitClient.grpApi().getAppliedGroups()
-            }.onSuccess { response ->
-                val groups = response.body()?.result?.applicationList
-                    ?.filter { it.applicationStatus == "PENDING" }
-                    ?.map { it.toGroupItem() } ?: return@onSuccess
-                _uiState.update { it.copy(appliedGroups = groups) }
-            }.onFailure { e ->
-                Log.e("HomeVM", "fetchAppliedGroups error", e)
-            }
+    private fun fetchAppliedGroups() = viewModelScope.launch { loadAppliedGroups() }
+
+    private suspend fun loadAppliedGroups() {
+        runCatching {
+            RetrofitClient.grpApi().getAppliedGroups()
+        }.onSuccess { response ->
+            val groups = response.body()?.result?.applicationList
+                ?.filter { it.applicationStatus == "PENDING" }
+                ?.map { it.toGroupItem() } ?: return@onSuccess
+            _uiState.update { it.copy(appliedGroups = groups) }
+        }.onFailure { e ->
+            Log.e("HomeVM", "fetchAppliedGroups error", e)
         }
     }
 }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/HomeScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -47,6 +49,7 @@ fun HomeRoute(
     HomeScreen(
         uiState = uiState,
         onTabSelect = viewModel::selectTab,
+        onRefresh = viewModel::refresh,
         onGroupClick = onGroupClick,
         onSearchClick = onSearchClick,
         onCreateGroupClick = onCreateGroupClick,
@@ -59,11 +62,12 @@ fun HomeRoute(
 
 // ─── Stateless 레이아웃 ───────────────────────────────────────────────────────
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 internal fun HomeScreen(
     uiState: HomeUiState,
     onTabSelect: (HomeTab) -> Unit,
+    onRefresh: () -> Unit,
     onGroupClick: (Long) -> Unit,
     onSearchClick: () -> Unit,
     onCreateGroupClick: () -> Unit,
@@ -93,47 +97,53 @@ internal fun HomeScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        LazyColumn(
-            state = lazyListState,
-            modifier = Modifier
-                .fillMaxSize()
-                .background(BookiiBookiiTheme.colors.uiBg),
-            contentPadding = PaddingValues(bottom = 100.dp),
+        PullToRefreshBox(
+            isRefreshing = uiState.isLoading,
+            onRefresh = onRefresh,
+            modifier = Modifier.fillMaxSize(),
         ) {
-            // [0] 웰컴섹션 — 맨 위에서만 보임
-            item { HomeWelcomeSection(nickname = uiState.nickname) }
+            LazyColumn(
+                state = lazyListState,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(BookiiBookiiTheme.colors.uiBg),
+                contentPadding = PaddingValues(bottom = 100.dp),
+            ) {
+                // [0] 웰컴섹션 — 맨 위에서만 보임
+                item { HomeWelcomeSection(nickname = uiState.nickname) }
 
-            // [1] 검색창+그룹생성 — 일반 아이템: 맨 위에서만 보이고 스크롤하면 자연스럽게 사라짐
-            // (sticky에서 빼서 헤더 높이를 고정 → 스크롤 점프/자동 스크롤 현상 제거)
-            item {
-                HomeSearchCreateRow(
-                    onSearchClick = onSearchClick,
-                    onCreateGroupClick = onCreateGroupClick,
-                )
-            }
+                // [1] 검색창+그룹생성 — 일반 아이템: 맨 위에서만 보이고 스크롤하면 자연스럽게 사라짐
+                // (sticky에서 빼서 헤더 높이를 고정 → 스크롤 점프/자동 스크롤 현상 제거)
+                item {
+                    HomeSearchCreateRow(
+                        onSearchClick = onSearchClick,
+                        onCreateGroupClick = onCreateGroupClick,
+                    )
+                }
 
-            // [2] stickyHeader: 탭바만 고정 — 높이가 변하지 않아 스크롤 점프 없음
-            stickyHeader {
-                HomeTabRow(selectedTab = uiState.selectedTab, onTabSelect = onTabSelect)
-            }
+                // [2] stickyHeader: 탭바만 고정 — 높이가 변하지 않아 스크롤 점프 없음
+                stickyHeader {
+                    HomeTabRow(selectedTab = uiState.selectedTab, onTabSelect = onTabSelect)
+                }
 
-            when (uiState.selectedTab) {
-                HomeTab.RECOMMEND -> homeRecommendContent(
-                    sections = uiState.recommendSections,
-                    onGroupClick = onGroupClick,
-                    onBookClick = onBookClick,
-                )
-                HomeTab.MY_GROUPS -> homeMyGroupsContent(
-                    myGroups = uiState.myGroups,
-                    onGroupClick = onGroupClick,
-                    onCreateGroupClick = onCreateGroupClick,
-                )
-                HomeTab.APPLIED -> homeAppliedContent(
-                    appliedGroups = uiState.appliedGroups,
-                    onGroupClick = onGroupClick,
-                    // "그룹 탐색하기" → 그룹 검색 화면(GroupSearchScreen)
-                    onExploreGroupClick = onSearchClick,
-                )
+                when (uiState.selectedTab) {
+                    HomeTab.RECOMMEND -> homeRecommendContent(
+                        sections = uiState.recommendSections,
+                        onGroupClick = onGroupClick,
+                        onBookClick = onBookClick,
+                    )
+                    HomeTab.MY_GROUPS -> homeMyGroupsContent(
+                        myGroups = uiState.myGroups,
+                        onGroupClick = onGroupClick,
+                        onCreateGroupClick = onCreateGroupClick,
+                    )
+                    HomeTab.APPLIED -> homeAppliedContent(
+                        appliedGroups = uiState.appliedGroups,
+                        onGroupClick = onGroupClick,
+                        // "그룹 탐색하기" → 그룹 검색 화면(GroupSearchScreen)
+                        onExploreGroupClick = onSearchClick,
+                    )
+                }
             }
         }
     }
@@ -170,6 +180,7 @@ private fun HomeScreenRecommendPreview() {
                 recommendSections = mockSections,
             ),
             onTabSelect = {},
+            onRefresh = {},
             onGroupClick = {},
             onSearchClick = {},
             onCreateGroupClick = {},
@@ -190,6 +201,7 @@ private fun HomeScreenRecommendEmptyPreview() {
                 recommendSections = emptyList(),
             ),
             onTabSelect = {},
+            onRefresh = {},
             onGroupClick = {},
             onSearchClick = {},
             onCreateGroupClick = {},
@@ -210,6 +222,7 @@ private fun HomeScreenMyGroupsEmptyPreview() {
                 myGroups = emptyList(),
             ),
             onTabSelect = {},
+            onRefresh = {},
             onGroupClick = {},
             onSearchClick = {},
             onCreateGroupClick = {},
@@ -230,6 +243,7 @@ private fun HomeScreenAppliedEmptyPreview() {
                 appliedGroups = emptyList(),
             ),
             onTabSelect = {},
+            onRefresh = {},
             onGroupClick = {},
             onSearchClick = {},
             onCreateGroupClick = {},

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeGroupCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeGroupCard.kt
@@ -55,7 +55,7 @@ internal fun HomeGroupCard(
             verticalArrangement = Arrangement.SpaceBetween,
         ) {
             // 상단: 교환방식 칩 + 책 제목 + 저자(장르)
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                     verticalAlignment = Alignment.CenterVertically,
@@ -89,7 +89,7 @@ internal fun HomeGroupCard(
             }
 
             // 하단: 예상 독서 기간 + 호스트 정보
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 // 피그마: "예상 독서 기간"(grey700) + "7"(grey800) + "일"(grey700) — 3개 분리
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeRecommendBookSections.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeRecommendBookSections.kt
@@ -47,6 +47,7 @@ internal fun BookThumbnail(
     ) {
         BookCover(
             imageUrl = book.bookImage,
+            aladinCoverSize = "cover200",
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(120f / 168f),
@@ -82,7 +83,10 @@ internal fun RecommendBookRow(
         contentPadding = PaddingValues(start = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        items(books) { book ->
+        items(
+            items = books,
+            key = { book -> book.isbn13 ?: book.title.orEmpty() },
+        ) { book ->
             BookThumbnail(
                 book = book,
                 onClick = { onBookClick(book) },

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeRecommendGroupCard.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeRecommendGroupCard.kt
@@ -49,7 +49,7 @@ internal fun RecommendGroupRow(
             state = pagerState,
             pageSize = PageSize.Fixed(334.dp),
             pageSpacing = 12.dp,
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp),
             // 한 번 스와이프 = 한 장씩(Pager 기본) + 느리고 묵직한 스냅으로 무게감.
             // 더 빠르게/덜 묵직하게 하려면 stiffness를 올리면 됨(StiffnessLow→MediumLow→Medium).
             flingBehavior = PagerDefaults.flingBehavior(
@@ -107,12 +107,6 @@ private fun HomeRecommendGroupCard(
     Column(
         modifier = modifier
             .width(334.dp)
-            .shadow(
-                elevation = 8.dp,
-                shape = shape,
-                ambientColor = Color(0x33000000),
-                spotColor = Color(0x33000000),
-            )
             .clip(shape)
             .background(colors.white)
             .clickable(onClick = onClick)
@@ -126,6 +120,7 @@ private fun HomeRecommendGroupCard(
         ) {
             BookCover(
                 imageUrl = group.bookImage,
+                aladinCoverSize = "cover200",
                 modifier = Modifier.size(width = 72.dp, height = 100.dp),
             )
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeTabRow.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/component/HomeTabRow.kt
@@ -78,7 +78,7 @@ internal fun HomeTabRow(
                                 strokeWidth = strokeWidth,
                             )
                         }
-                        .padding(end = 4.dp, bottom = 16.dp),
+                        .padding(start = 4.dp, end = 4.dp, bottom = 16.dp),
                 )
             }
         }

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeAppliedContent.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeAppliedContent.kt
@@ -112,8 +112,6 @@ internal fun LazyListScope.homeAppliedContent(
         }
     }
 
-    // 하단 여백
-    item { Box(Modifier.height(80.dp)) }
 }
 
 // ─── 프리뷰 ───────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeMyGroupsContent.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeMyGroupsContent.kt
@@ -112,8 +112,6 @@ internal fun LazyListScope.homeMyGroupsContent(
         }
     }
 
-    // 하단 여백
-    item { Box(Modifier.height(80.dp)) }
 }
 
 // ─── 프리뷰 ───────────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeRecommendContent.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/home/ui/content/HomeRecommendContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -19,7 +21,7 @@ import com.bookiibookii.bookiibookii.data.model.group.GroupItem
 import com.bookiibookii.bookiibookii.data.model.group.HomeLayoutType
 import com.bookiibookii.bookiibookii.data.model.group.HomeSection
 import com.bookiibookii.bookiibookii.data.model.group.HomeSectionItem
-import com.bookiibookii.bookiibookii.home.ui.component.RecommendBookGrid
+import com.bookiibookii.bookiibookii.home.ui.component.BookThumbnail
 import com.bookiibookii.bookiibookii.home.ui.component.RecommendBookRow
 import com.bookiibookii.bookiibookii.home.ui.component.RecommendGroupRow
 import com.bookiibookii.bookiibookii.ui.preview.BookiiPreview
@@ -30,7 +32,12 @@ internal fun LazyListScope.homeRecommendContent(
     onGroupClick: (Long) -> Unit,
     onBookClick: (HomeSectionItem) -> Unit = {},
 ) {
-    item { Box(Modifier.fillMaxWidth().height(8.dp)) }
+    item(
+        key = "recommend-top-spacer",
+        contentType = "spacer",
+    ) {
+        Box(Modifier.fillMaxWidth().height(8.dp))
+    }
 
     // 아이템 없는 섹션 + 미지원 레이아웃은 숨김. 나머지는 응답 순서대로 렌더.
     val visibleSections = sections.filter {
@@ -39,19 +46,19 @@ internal fun LazyListScope.homeRecommendContent(
 
     visibleSections.forEachIndexed { index, section ->
         if (index > 0) {
-            item { Box(Modifier.fillMaxWidth().height(8.dp)) }
+            item(
+                key = "${section.sectionType}-$index-spacer",
+                contentType = "spacer",
+            ) { Box(Modifier.fillMaxWidth().height(8.dp)) }
         }
-        item {
-            when (section.layoutType) {
-                HomeLayoutType.GROUP_CARD_CAROUSEL -> GroupCarouselSection(section, onGroupClick)
-                HomeLayoutType.BOOK_THUMBNAIL_CAROUSEL -> BookCarouselSection(section, onBookClick)
-                HomeLayoutType.BOOK_THUMBNAIL_GRID -> BookGridSection(section, onBookClick)
-            }
+
+        when (section.layoutType) {
+            HomeLayoutType.GROUP_CARD_CAROUSEL -> groupCarouselSectionItems(index, section, onGroupClick)
+            HomeLayoutType.BOOK_THUMBNAIL_CAROUSEL -> bookCarouselSectionItems(index, section, onBookClick)
+            HomeLayoutType.BOOK_THUMBNAIL_GRID -> bookGridSectionItems(index, section, onBookClick)
         }
     }
 
-    // 하단 여백
-    item { Box(Modifier.height(80.dp)) }
 }
 
 private val SUPPORTED_LAYOUTS = setOf(
@@ -60,77 +67,128 @@ private val SUPPORTED_LAYOUTS = setOf(
     HomeLayoutType.BOOK_THUMBNAIL_GRID,
 )
 
-// 그룹 카드 캐러셀
-@Composable
-private fun GroupCarouselSection(
+private fun LazyListScope.sectionHeaderItem(
+    sectionIndex: Int,
+    section: HomeSection,
+) {
+    item(
+        key = "${section.sectionType}-$sectionIndex-header",
+        contentType = "section-header",
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BookiiBookiiTheme.colors.white)
+                .padding(start = 16.dp, top = 16.dp, end = 16.dp),
+        ) {
+            HomeSectionHeader(
+                title = section.title,
+                subtitle = section.subtitle,
+            )
+        }
+    }
+}
+
+private fun LazyListScope.groupCarouselSectionItems(
+    sectionIndex: Int,
     section: HomeSection,
     onGroupClick: (Long) -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(BookiiBookiiTheme.colors.white)
-            .padding(top = 16.dp, bottom = 16.dp),
+    sectionHeaderItem(sectionIndex, section)
+    item(
+        key = "${section.sectionType}-$sectionIndex-content",
+        contentType = HomeLayoutType.GROUP_CARD_CAROUSEL,
     ) {
-        HomeSectionHeader(
-            title = section.title,
-            subtitle = section.subtitle,
-            modifier = Modifier.padding(horizontal = 16.dp),
-        )
-        Box(Modifier.height(12.dp))
-        RecommendGroupRow(
-            groups = section.items.map { it.toGroupItem() },
-            onGroupClick = onGroupClick,
-        )
+        val groups = remember(section.items) { section.items.map { it.toGroupItem() } }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BookiiBookiiTheme.colors.white)
+                .padding(bottom = 16.dp),
+        ) {
+            Box(Modifier.height(12.dp))
+            RecommendGroupRow(
+                groups = groups,
+                onGroupClick = onGroupClick,
+            )
+        }
     }
 }
 
-// 책 썸네일 캐러셀
-@Composable
-private fun BookCarouselSection(
+private fun LazyListScope.bookCarouselSectionItems(
+    sectionIndex: Int,
     section: HomeSection,
     onBookClick: (HomeSectionItem) -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(BookiiBookiiTheme.colors.white)
-            .padding(top = 16.dp, bottom = 24.dp),
+    sectionHeaderItem(sectionIndex, section)
+    item(
+        key = "${section.sectionType}-$sectionIndex-content",
+        contentType = HomeLayoutType.BOOK_THUMBNAIL_CAROUSEL,
     ) {
-        HomeSectionHeader(
-            title = section.title,
-            subtitle = section.subtitle,
-            modifier = Modifier.padding(start = 16.dp),
-        )
-        Spacer(Modifier.height(16.dp))
-        RecommendBookRow(
-            books = section.items,
-            onBookClick = onBookClick,
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BookiiBookiiTheme.colors.white)
+                .padding(bottom = 24.dp),
+        ) {
+            Spacer(Modifier.height(16.dp))
+            RecommendBookRow(
+                books = section.items,
+                onBookClick = onBookClick,
+            )
+        }
     }
 }
 
-// 책 썸네일 그리드
-@Composable
-private fun BookGridSection(
+private fun LazyListScope.bookGridSectionItems(
+    sectionIndex: Int,
     section: HomeSection,
     onBookClick: (HomeSectionItem) -> Unit,
+    columns: Int = 3,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(BookiiBookiiTheme.colors.white)
-            .padding(16.dp),
+    sectionHeaderItem(sectionIndex, section)
+    item(
+        key = "${section.sectionType}-$sectionIndex-grid-spacer",
+        contentType = "section-content-spacer",
     ) {
-        HomeSectionHeader(
-            title = section.title,
-            subtitle = section.subtitle,
-        )
-        Spacer(Modifier.height(16.dp))
-        RecommendBookGrid(
-            books = section.items,
-            onBookClick = onBookClick,
-        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BookiiBookiiTheme.colors.white),
+        ) {
+            Spacer(Modifier.height(16.dp))
+        }
+    }
+
+    val rows = section.items.chunked(columns)
+    rows.forEachIndexed { rowIndex, rowBooks ->
+        item(
+            key = "${section.sectionType}-$sectionIndex-row-$rowIndex",
+            contentType = "book-grid-row",
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(BookiiBookiiTheme.colors.white)
+                    .padding(
+                        start = 16.dp,
+                        end = 16.dp,
+                        bottom = if (rowIndex == rows.lastIndex) 16.dp else 8.dp,
+                    ),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                rowBooks.forEach { book ->
+                    BookThumbnail(
+                        book = book,
+                        onClick = { onBookClick(book) },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+                repeat(columns - rowBooks.size) {
+                    Spacer(Modifier.weight(1f))
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/BookCover.kt
+++ b/app/src/main/java/com/bookiibookii/bookiibookii/ui/component/BookCover.kt
@@ -31,6 +31,7 @@ private fun String.toAladinCover(size: String): String =
 fun BookCover(
     modifier: Modifier = Modifier,
     imageUrl: String? = null,
+    aladinCoverSize: String = "cover500",
 ) {
     val shape = BookiiBookiiTheme.shape.round8
     Box(
@@ -44,10 +45,10 @@ fun BookCover(
             ),
     ) {
         if (!imageUrl.isNullOrBlank()) {
-            val highRes = imageUrl.toAladinCover("cover500")
+            val highRes = imageUrl.toAladinCover(aladinCoverSize)
             val fallback = imageUrl.toAladinCover("cover200")
             // cover500이 없는 책은 로딩 실패 → cover200으로 1회 폴백
-            var model by remember(imageUrl) { mutableStateOf(highRes) }
+            var model by remember(imageUrl, aladinCoverSize) { mutableStateOf(highRes) }
             AsyncImage(
                 model = model,
                 contentDescription = null,


### PR DESCRIPTION
# 📌 Pull Request Title
ui: 탐색화면 4차 QA 반영

---

# ✨ 작업 내용 (What)
  - 탐색화면 최상단에서 위로 당기면 새로고침되는 Pull-to-refresh 기능 추가
  - 그룹 검색 화면 진입 시 검색창 자동 포커스 (기존: 검색창 두 번 탭해야 입력 가능)
  - 추천 탭 그룹 카드 그림자 제거 (Figma 디자인 기준)
  - 추천 탭 그룹 카드 상하 여백 수정 (Figma 기준 맞춤)
  - 내 그룹 / 신청한 그룹 탭 하단 여백 과다 수정
  - 내 그룹 / 신청한 그룹 카드 내부 텍스트 간격 수정 (4dp → 6dp)
  - 추천 섹션 레이아웃 구조 개선 (섹션별 상하 패딩/간격 Figma 기준 맞춤)
  - 추천 책 섹션 이미지 해상도 개선 (cover200)
  - 추천 책 목록 LazyRow key 적용으로 리컴포지션 최적화
  - HomeViewModel 리팩토링: fetch*/load* 분리 구조로 개선 (Pull-to-refresh 병렬 로딩 지원)


---

# 🧪 테스트 방법 (How to Test)
  - 탐색화면 → 최상단에서 위로 당기면 로딩 인디케이터 노출 후 데이터 갱신 확인
  - 그룹 검색 탭 → 화면 진입 즉시 키보드 올라오며 검색창 활성화 확인
  - 추천 탭 → 그룹 카드 그림자 없음, 카드 간 여백 Figma와 동일 확인
  - 내 그룹 / 신청한 그룹 탭 → 카드 내부 텍스트 간격 및 하단 여백 확인


---

# 💡추가 사항
> 추가로 작성할 것이 있다면 여기에 작성해주세요!

---

# 🔗 관련 이슈 (Optional)
- close #437
